### PR TITLE
Feature/#30 회원가입 1단계 UI 구현

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,27 +7,27 @@ import DefaultLayout from './components/layouts/DefaultLayout.vue';
 const route = useRoute();
 
 // 헤더/풋터가 없어야 하는 페이지 목록
-const pagesWithoutHeaderFooter = ['/auth/login'];
+const pagesWithoutHeaderFooter = ['/auth/login', '/signup/step1/local'];
 
 const showHeaderFooter = computed(() => {
-  return !pagesWithoutHeaderFooter.includes(route.path);
+    return !pagesWithoutHeaderFooter.includes(route.path);
 });
 </script>
 
 <template>
-  <DefaultLayout v-if="showHeaderFooter">
-    <RouterView />
-  </DefaultLayout>
-  <div v-else class="no-layout-wrapper">
-    <RouterView />
-  </div>
+    <DefaultLayout v-if="showHeaderFooter">
+        <RouterView />
+    </DefaultLayout>
+    <div v-else class="no-layout-wrapper">
+        <RouterView />
+    </div>
 </template>
 
 <style scoped>
 .no-layout-wrapper {
-  min-height: 100vh;
-  background-color: #f8f9fa;
-  width: 100%;
-  overflow-x: hidden;
+    min-height: 100vh;
+    background-color: #f8f9fa;
+    width: 100%;
+    overflow-x: hidden;
 }
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,7 +7,11 @@ import DefaultLayout from './components/layouts/DefaultLayout.vue';
 const route = useRoute();
 
 // 헤더/풋터가 없어야 하는 페이지 목록
-const pagesWithoutHeaderFooter = ['/auth/login', '/signup/step1/local'];
+const pagesWithoutHeaderFooter = [
+    '/auth/login',
+    '/signup/step1/local',
+    '/signup/step1/kakao',
+];
 
 const showHeaderFooter = computed(() => {
     return !pagesWithoutHeaderFooter.includes(route.path);

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,42 +1,62 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;200;300;400;500;600;700;800;900&display=swap');
+/* 실제 적용 예정인 폰트 */
+@font-face {
+    font-family: 'Pretendard-Regular';
+    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')
+        format('woff');
+    font-weight: 400;
+    font-style: normal;
+}
+
+/* 테스트용 폰트 */
+@font-face {
+    font-family: 'SF_HambakSnow';
+    src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2106@1.1/SF_HambakSnow.woff')
+        format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+* {
+    font-family: 'SF_HambakSnow';
+}
 html,
 body {
-  background-color: #fbfbfb;
+    background-color: #fbfbfb;
 }
 /* 페이지 네이션 */
 .pagination-container {
-  display: flex;
-  /* column-gap: 10px; */
+    display: flex;
+    /* column-gap: 10px; */
 }
 .paginate-buttons {
-  height: 40px;
-  width: 40px;
-  cursor: pointer;
-  background-color: rgb(255, 255, 255); /*rgb(242, 242, 242);*/
-  border: 1px solid white; /* rgb(217, 217, 217);*/
-  color: rgb(63, 63, 63);
+    height: 40px;
+    width: 40px;
+    cursor: pointer;
+    background-color: rgb(255, 255, 255); /*rgb(242, 242, 242);*/
+    border: 1px solid white; /* rgb(217, 217, 217);*/
+    color: rgb(63, 63, 63);
 }
 .paginate-buttons:hover {
-  background-color: #f0efef;
-  border-radius: 5px;
+    background-color: #f0efef;
+    border-radius: 5px;
 }
 .active-page {
-  color: black;
-  font-weight: bold;
+    color: black;
+    font-weight: bold;
 }
 .active-page:hover {
-  background-color: #f2f2f2;
+    background-color: #f2f2f2;
 }
 
 /* assets/main.css 파일에 추가 */
 
 /* Bootstrap container 제한 완전 해제 */
 #app {
-  margin: 0 !important;
-  padding: 0 !important;
-  width: 100% !important;
-  max-width: none !important;
-  min-height: 100vh;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100% !important;
+    max-width: none !important;
+    min-height: 100vh;
 }
 
 /* 모든 container 클래스들의 제한 해제 */
@@ -46,28 +66,28 @@ body {
 .container-lg,
 .container-xl,
 .container-xxl {
-  max-width: none !important;
-  padding-left: 0 !important;
-  padding-right: 0 !important;
+    max-width: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
 }
 
 /* 기본 여백 제거 */
 * {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
 }
 
 body,
 html {
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  overflow-x: hidden;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    overflow-x: hidden;
 }
 
 /* Bootstrap gutter 제거 */
 :root {
-  --bs-gutter-x: 0 !important;
-  --bs-gutter-y: 0 !important;
+    --bs-gutter-x: 0 !important;
+    --bs-gutter-y: 0 !important;
 }

--- a/frontend/src/components/PrivacyPolicyModal.vue
+++ b/frontend/src/components/PrivacyPolicyModal.vue
@@ -1,0 +1,243 @@
+<script setup>
+import { defineEmits } from 'vue';
+
+const emit = defineEmits(['close', 'agree']);
+
+const handleAgree = () => {
+    emit('agree', {
+        agreeSub1: true,
+        agreeSub2: true,
+        agreeSub0: true,
+        agreed: true,
+    });
+    emit('close');
+};
+
+const handleReject = () => {
+    emit('agree', {
+        agreeSub1: false,
+        agreeSub2: false,
+        agreeSub0: false,
+        agreed: false,
+    });
+    emit('close');
+};
+</script>
+
+<template>
+    <div class="modal-backdrop">
+        <div class="privacy-modal">
+            <div class="modal-header">
+                <h2>개인(신용)정보 수집·이용 동의</h2>
+            </div>
+
+            <div class="modal-content-scrollable">
+                <div class="modal-section">
+                    <h3>
+                        [필수] 전자금융거래 회원가입을 위한 개인(신용)정보 처리
+                        동의서
+                    </h3>
+
+                    <h4>수집·이용 목적</h4>
+                    <ul>
+                        <li>전자금융거래 회원가입 및 회원관리</li>
+                        <li>전자금융서비스 제공, 유지, 관리, 개선</li>
+                        <li>상담, 민원 분쟁 해결, 법령상 의무 이행</li>
+                        <li>본인 여부 확인, 이상금융거래 예방 및 조사 관리</li>
+                    </ul>
+
+                    <h4>보유 및 이용기간</h4>
+                    <p>
+                        · 동의일로부터 거래 종료 시까지<br />
+                        (단, 관련 법령에 따른 보존기간 존재 시 해당 기간까지)
+                    </p>
+                </div>
+
+                <div class="modal-section">
+                    <h4>거부 권리 및 불이익</h4>
+                    <p>
+                        · 동의를 거부할 수 있으나, 본 동의는 회원가입에
+                        필수이므로 거부 시 가입 불가
+                    </p>
+                </div>
+
+                <div class="modal-section">
+                    <h4>수집·이용 항목</h4>
+
+                    <strong>고유식별정보</strong>
+                    <p>· 주민등록번호, 외국인등록번호</p>
+                    <p>※ 고유식별정보 수집·이용에 동의하십니까?</p>
+                    <div class="radio-group">
+                        <label><input type="radio" disabled /> 동의</label>
+                        <label><input type="radio" disabled /> 동의안함</label>
+                    </div>
+
+                    <strong>개인(신용)정보</strong>
+                    <p>· 일반개인정보</p>
+                    <p class="info-text">
+                        성명, 생년월일, 성별, 본인확인정보(C.I, D.I),
+                        휴대폰번호, 이메일, 영문명, 국적, 주소, 연락처, 내외국인
+                        구분, 쿠키정보, 고유식별번호(ID), ADID, IDFA,
+                        모바일기기정보, OS정보, 접속로그, 브라우저정보, IP주소,
+                        단말정보(UUID, IMEI, MAC주소), 악성앱 및 원격앱 설치
+                        구동 정보
+                    </p>
+                    <p>※ 개인신용정보 수집·이용에 동의하십니까?</p>
+                    <div class="radio-group">
+                        <label><input type="radio" disabled /> 동의</label>
+                        <label><input type="radio" disabled /> 동의안함</label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="modal-footer">
+                <p class="confirm-text">
+                    위 내용을 충분히 확인했으며 이에 동의합니다.
+                </p>
+                <div class="button-group">
+                    <button class="reject" @click="handleReject">
+                        동의안함
+                    </button>
+                    <button class="accept" @click="handleAgree">동의함</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.privacy-modal {
+    display: flex;
+    flex-direction: column;
+    height: 90vh;
+    width: 95%;
+    max-width: 600px;
+    background: #fff;
+    border-radius: 30px;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    font-size: 14px;
+    line-height: 1.5;
+    color: #333;
+}
+
+.modal-header {
+    flex-shrink: 0;
+    padding: 20px 24px 8px;
+    text-align: center;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.modal-header h2 {
+    display: inline-block;
+    font-size: 18px;
+    margin: 0 auto;
+    text-align: center;
+    font-weight: 600;
+}
+
+.modal-content-scrollable {
+    flex-grow: 1;
+    overflow-y: auto;
+    padding: 16px 24px;
+}
+
+.modal-section {
+    margin-bottom: 20px;
+}
+
+.modal-section h3 {
+    font-size: 15px;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.modal-section h4 {
+    font-size: 14px;
+    font-weight: 500;
+    margin: 10px 0 6px;
+}
+
+.modal-section ul {
+    padding-left: 18px;
+    margin-bottom: 10px;
+}
+
+.modal-section li {
+    font-size: 13px;
+    margin-bottom: 4px;
+}
+
+.modal-section p {
+    font-size: 13px;
+    margin: 4px 0;
+}
+
+.info-text {
+    font-size: 12.5px;
+    color: #555;
+    margin: 6px 0;
+}
+
+.radio-group {
+    display: flex;
+    gap: 16px;
+    margin: 10px 0;
+    opacity: 0.6;
+    font-size: 13px;
+}
+
+.modal-footer {
+    flex-shrink: 0;
+    padding: 16px 24px;
+    background-color: #fafafa;
+    border-top: 1px solid #eee;
+    flex-direction: column;
+}
+
+.confirm-text {
+    padding-bottom: 10px;
+}
+
+.button-group {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.reject,
+.accept {
+    flex: 1;
+    min-width: 200px;
+    padding: 12px 0;
+    font-size: 14px;
+    border: none;
+    border-radius: 30px;
+    cursor: pointer;
+    text-align: center;
+}
+
+.reject {
+    background: #f2f2f2;
+    color: #222;
+}
+
+.accept {
+    background-color: #0066ff;
+    color: white;
+}
+</style>

--- a/frontend/src/pages/auth/LoginPage.vue
+++ b/frontend/src/pages/auth/LoginPage.vue
@@ -1,256 +1,262 @@
 <script setup>
-import { reactive, ref, computed } from 'vue'
-import { useRouter } from 'vue-router'
-import { userAuthStore } from '@/stores/auth'
-import kakaoLogin from '@/assets/images/kakao_login.png'
-import logo from '@/assets/logo.svg'
+import { reactive, ref, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { userAuthStore } from '@/stores/auth';
+import kakaoLogin from '@/assets/images/kakao_login.png';
+import logo from '@/assets/logo.svg';
 
-const router = useRouter()
-const auth = userAuthStore()
+const router = useRouter();
+const auth = userAuthStore();
 
 const user = reactive({
-  email: '',
-  password: '',
-})
+    email: '',
+    password: '',
+});
 
-const error = ref('')
-const disableSubmit = computed(() => !(user.email && user.password))
+const error = ref('');
+const disableSubmit = computed(() => !(user.email && user.password));
 
 const handleLogin = async () => {
-  if (!user.email) {
-    alert('이메일을 입력해주세요.')
-    return
-  }
-  if (!user.password) {
-    alert('비밀번호를 입력해주세요.')
-    return
-  }
-  try {
-    await auth.login(user)
-    router.push('/')
-  } catch (e) {
-    console.error('에러=======', e)
-    alert(e.response?.data || '로그인에 실패했습니다. 다시 시도해주세요.')
-  }
-}
+    if (!user.email) {
+        alert('이메일을 입력해주세요.');
+        return;
+    }
+    if (!user.password) {
+        alert('비밀번호를 입력해주세요.');
+        return;
+    }
+    try {
+        await auth.login(user);
+        router.push('/');
+    } catch (e) {
+        console.error('에러=======', e);
+        alert(e.response?.data || '로그인에 실패했습니다. 다시 시도해주세요.');
+    }
+};
 
 const handleKakaoLogin = () => {
-  window.location.href = 'https://kauth.kakao.com/oauth/authorize?...' // 실제 인증 URL로 교체
-}
+    window.location.href = 'https://kauth.kakao.com/oauth/authorize?...'; // 실제 인증 URL로 교체
+};
+
+const handleSignup = () => {
+    router.push('/signup/step1/local');
+};
 </script>
 
 <template>
-  <div class="container">
-    <router-link to="/" class="logo-section text-decoration-none">
-      <div class="logo d-flex align-items-center">
-        <img src="@/assets/logo.svg" alt="로고" class="logo-icon" />
-      </div>
-    </router-link>
+    <div class="container">
+        <router-link to="/" class="logo-section text-decoration-none">
+            <div class="logo d-flex align-items-center">
+                <img src="@/assets/logo.svg" alt="로고" class="logo-icon" />
+            </div>
+        </router-link>
 
-    <div class="login-box">
-      <div class="title">로그인</div>
+        <div class="login-box">
+            <div class="title">로그인</div>
 
-      <div class="form-group">
-        <label for="email">이메일</label>
-        <input
-          id="email"
-          type="email"
-          v-model="user.email"
-          placeholder="이메일을 입력하세요"
-        />
-      </div>
+            <div class="form-group">
+                <label for="email">이메일</label>
+                <input
+                    id="email"
+                    type="email"
+                    v-model="user.email"
+                    placeholder="이메일을 입력하세요"
+                />
+            </div>
 
-      <div class="form-group">
-        <label for="password">비밀번호</label>
-        <input
-          id="password"
-          type="password"
-          v-model="user.password"
-          placeholder="비밀번호를 입력하세요"
-        />
-      </div>
+            <div class="form-group">
+                <label for="password">비밀번호</label>
+                <input
+                    id="password"
+                    type="password"
+                    v-model="user.password"
+                    placeholder="비밀번호를 입력하세요"
+                />
+            </div>
 
-      <div class="forgot-password">
-        <router-link to="/find-password">비밀번호를 잊으셨나요?</router-link>
-      </div>
+            <div class="forgot-password">
+                <router-link to="/find-password"
+                    >비밀번호를 잊으셨나요?</router-link
+                >
+            </div>
 
-      <button class="login-button button-like" @click="handleLogin">
-        로그인
-      </button>
+            <button class="login-button button-like" @click="handleLogin">
+                로그인
+            </button>
 
-      <img
-        class="kakao-login button-like"
-        alt="Kakao login"
-        :src="kakaoLogin"
-        @click="handleKakaoLogin"
-      />
+            <img
+                class="kakao-login button-like"
+                alt="Kakao login"
+                :src="kakaoLogin"
+                @click="handleKakaoLogin"
+            />
 
-      <p class="sign-up-prompt">
-        <span>아직 콕재 회원이 아닌가요?&nbsp;</span>
-        <span class="sign-up">가입하기</span>
-      </p>
+            <p class="sign-up-prompt">
+                <span>아직 콕재 회원이 아닌가요?&nbsp;</span>
+                <span class="sign-up" @click="handleSignup">가입하기</span>
+            </p>
+        </div>
     </div>
-  </div>
 </template>
 
 <style>
 .container {
-  background-color: #fafafa;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  min-height: 100vh;
-  padding: 0 16px 40px 16px;
-  position: relative;
+    background-color: #fafafa;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
+    padding: 0 16px 40px 16px;
+    position: relative;
 }
 
 /* header */
 .header {
-  position: absolute;
-  top: 20px;
-  left: 20px;
+    position: absolute;
+    top: 20px;
+    left: 20px;
 }
 
 .logo {
-  height: 50px;
-  width: 50px;
-  object-fit: cover;
+    height: 50px;
+    width: 50px;
+    object-fit: cover;
 }
 
 .logo-section {
-  cursor: pointer;
-  transition: transform 0.2s ease;
-  background-color: transparent;
-  flex-shrink: 0;
-  margin-left: 20px;
-  margin-top: 10px;
-  margin-bottom: 0;
-  align-self: flex-start;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+    background-color: transparent;
+    flex-shrink: 0;
+    margin-left: 20px;
+    margin-top: 10px;
+    margin-bottom: 0;
+    align-self: flex-start;
 }
 .logo-section:hover {
-  transform: scale(1.05);
+    transform: scale(1.05);
 }
 .logo {
-  background-color: transparent;
+    background-color: transparent;
 }
 .logo-icon {
-  width: 54px;
-  height: 54px;
-  background: transparent !important;
-  border-radius: 50%;
-  padding: 2px;
-  object-fit: contain;
+    width: 54px;
+    height: 54px;
+    background: transparent !important;
+    border-radius: 50%;
+    padding: 2px;
+    object-fit: contain;
 }
 
 /* login-box */
 .login-box {
-  background-color: #fff;
-  width: 100%;
-  max-width: 900px;
-  padding: 90px 140px;
-  border-radius: 28px;
-  box-shadow: 0 0 20px #85858540;
-  margin-top: 50px;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+    background-color: #fff;
+    width: 100%;
+    max-width: 900px;
+    padding: 90px 140px;
+    border-radius: 28px;
+    box-shadow: 0 0 20px #85858540;
+    margin-top: 50px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
 }
 
 .title {
-  background-color: #fff;
-  font-size: 24px;
-  font-weight: 600;
-  text-align: left;
+    background-color: #fff;
+    font-size: 24px;
+    font-weight: 600;
+    text-align: left;
 }
 
 .form-group {
-  display: flex;
-  flex-direction: column;
+    display: flex;
+    flex-direction: column;
 }
 
 .form-group label {
-  color: #686868;
-  font-size: 14px;
-  margin-bottom: 6px;
+    color: #686868;
+    font-size: 14px;
+    margin-bottom: 6px;
 }
 
 .form-group input {
-  background-color: #fff;
-  border-radius: 12px;
-  border: 1px solid #d9d9d9;
-  padding: 14px 16px;
-  font-size: 16px;
-  box-shadow: inset 0 0 5px #eee;
+    background-color: #fff;
+    border-radius: 12px;
+    border: 1px solid #d9d9d9;
+    padding: 14px 16px;
+    font-size: 16px;
+    box-shadow: inset 0 0 5px #eee;
 }
 
 .forgot-password {
-  background-color: #fff;
-  text-align: right;
-  color: #3573ee;
-  font-size: 14px;
-  cursor: pointer;
+    background-color: #fff;
+    text-align: right;
+    color: #3573ee;
+    font-size: 14px;
+    cursor: pointer;
 }
 
 .button-like {
-  width: 100%;
-  height: 60px;
-  border-radius: 12px;
-  display: block;
+    width: 100%;
+    height: 60px;
+    border-radius: 12px;
+    display: block;
 }
 
 .login-button {
-  background-color: #3573ee;
-  color: white;
-  padding: 0;
-  border: none;
-  font-size: 18px;
-  font-weight: 600;
-  cursor: pointer;
+    background-color: #3573ee;
+    color: white;
+    padding: 0;
+    border: none;
+    font-size: 18px;
+    font-weight: 600;
+    cursor: pointer;
 }
 
 .kakao-login {
-  object-fit: cover;
-  cursor: pointer;
-  border: none;
+    object-fit: cover;
+    cursor: pointer;
+    border: none;
 }
 
 .sign-up-prompt {
-  background-color: #fff;
-  text-align: center;
-  font-size: 16px;
+    background-color: #fff;
+    text-align: center;
+    font-size: 16px;
 }
 
 .sign-up {
-  color: #3573ee;
-  text-decoration: underline;
-  cursor: pointer;
+    color: #3573ee;
+    text-decoration: underline;
+    cursor: pointer;
 }
 
 /* 모바일 화면 대응 */
 @media (max-width: 768px) {
-  .login-box {
-    max-width: 100%;
-    padding: 40px 30px;
-    border-radius: 20px;
-  }
+    .login-box {
+        max-width: 100%;
+        padding: 40px 30px;
+        border-radius: 20px;
+    }
 
-  .title {
-    font-size: 22px;
-  }
+    .title {
+        font-size: 22px;
+    }
 
-  .login-button,
-  .button-like {
-    height: 50px;
-    font-size: 16px;
-  }
+    .login-button,
+    .button-like {
+        height: 50px;
+        font-size: 16px;
+    }
 
-  .form-group input {
-    font-size: 15px;
-    padding: 12px 14px;
-  }
+    .form-group input {
+        font-size: 15px;
+        padding: 12px 14px;
+    }
 
-  .sign-up-prompt {
-    font-size: 14px;
-  }
+    .sign-up-prompt {
+        font-size: 14px;
+    }
 }
 </style>

--- a/frontend/src/pages/auth/SignupStep1Kakao.vue
+++ b/frontend/src/pages/auth/SignupStep1Kakao.vue
@@ -1,0 +1,535 @@
+<script setup>
+import { reactive, ref, computed, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import PrivacyPolicyModal from '@/components/PrivacyPolicyModal.vue';
+
+const router = useRouter();
+
+const userInfo = reactive({
+    gender: '',
+    birth: '',
+    phone1: '',
+    phone2: '',
+    phone3: '',
+    agreed: false,
+    agreeSub0: false,
+    agreeSub1: false,
+    agreeSub2: false,
+});
+
+const isPolicyModalOpen = ref(false);
+
+// agreed 변경 시 동기화
+watch(
+    () => userInfo.agreed,
+    (val) => {
+        userInfo.agreeSub0 = val;
+        userInfo.agreeSub1 = val;
+        userInfo.agreeSub2 = val;
+    }
+);
+
+// agreeSub0 변경 시 동기화
+watch(
+    () => userInfo.agreeSub0,
+    (val) => {
+        userInfo.agreed = val;
+        userInfo.agreeSub1 = val;
+        userInfo.agreeSub2 = val;
+    }
+);
+
+// 동의 버튼
+const openModal = () => {
+    isPolicyModalOpen.value = true;
+};
+
+// 모달에서 가져온 값 적용
+const handlePolicyAgree = (agreeData) => {
+    userInfo.agreed = agreeData.agreed;
+    userInfo.agreeSub0 = agreeData.agreeSub0;
+    userInfo.agreeSub1 = agreeData.agreeSub1;
+    userInfo.agreeSub2 = agreeData.agreeSub2;
+    isPolicyModalOpen.value = false;
+};
+
+//
+const isFormValid = computed(() => {
+    return (
+        userInfo.gender &&
+        userInfo.birth &&
+        userInfo.phone1 &&
+        userInfo.phone2 &&
+        userInfo.phone3 &&
+        userInfo.agreed
+    );
+});
+
+// 다음 페이지
+const goNext = () => {
+    if (!isFormValid.value) return;
+    router.push('/signup/step2'); // 다음 단계로 라우팅
+};
+</script>
+
+<template>
+    <div class="container">
+        <router-link to="/" class="logo-section text-decoration-none">
+            <div class="logo d-flex align-items-center">
+                <img src="@/assets/logo.svg" alt="로고" class="logo-icon" />
+            </div>
+        </router-link>
+
+        <div class="signup-box">
+            <div class="top">
+                <div class="title">
+                    콕재 서비스를 이용하려면<br />회원 가입이 필요해요
+                </div>
+                <div class="page-num">1/3</div>
+            </div>
+
+            <hr />
+
+            <div class="title">개인정보 입력</div>
+
+            <div class="form-group">
+                <label>성별</label>
+                <div class="gender-group">
+                    <label>
+                        <input
+                            type="radio"
+                            value="M"
+                            v-model="userInfo.gender"
+                        />
+                        남성</label
+                    >
+                    <label>
+                        <input
+                            type="radio"
+                            value="F"
+                            v-model="userInfo.gender"
+                        />
+                        여성</label
+                    >
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label>생년월일</label>
+                <input type="date" v-model="userInfo.birth" />
+            </div>
+
+            <div class="form-group">
+                <label>전화번호</label>
+                <div class="phone-group">
+                    <select v-model="userInfo.phone1">
+                        <option value="">선택</option>
+                        <option value="010">010</option>
+                        <option value="011">011</option>
+                    </select>
+                    <input v-model="userInfo.phone2" maxlength="4" />
+                    <input v-model="userInfo.phone3" maxlength="4" />
+                </div>
+            </div>
+
+            <hr />
+
+            <div class="agreement">
+                <div class="agreement-con1">
+                    <label>
+                        <input type="checkbox" v-model="userInfo.agreed" />
+                        <strong>[필수] 개인(신용)정보 처리 동의</strong>
+                    </label>
+                </div>
+
+                <div class="agreement-con2">
+                    <div class="agreement-left">
+                        <div class="agreement-item">
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    v-model="userInfo.agreeSub0"
+                                />
+                                개인(신용)정보 수집·이용 동의
+                            </label>
+                        </div>
+                        <div class="agreement-sub-items">
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    v-model="userInfo.agreeSub1"
+                                    disabled
+                                />
+                                고유식별정보
+                            </label>
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    v-model="userInfo.agreeSub2"
+                                    disabled
+                                />
+                                개인(신용)정보
+                            </label>
+                        </div>
+                    </div>
+                    <div class="agreement-right">
+                        <button @click="openModal">＞</button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="button-group">
+                <button class="cancel-button" @click="router.push('/')">
+                    취소하기
+                </button>
+                <button
+                    :disabled="!isFormValid"
+                    class="next-button"
+                    @click="goNext"
+                >
+                    다음 단계
+                </button>
+            </div>
+        </div>
+    </div>
+    <PrivacyPolicyModal
+        v-if="isPolicyModalOpen"
+        @close="isPolicyModalOpen = false"
+        @agree="handlePolicyAgree"
+    />
+</template>
+
+<style scoped>
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
+    padding: 0 16px 40px 16px;
+    position: relative;
+}
+
+/* logo */
+.logo-section {
+    cursor: pointer;
+    margin: 15px 0 0 20px;
+    align-self: flex-start;
+    transition: transform 0.2s ease;
+}
+
+.logo-section:hover {
+    transform: scale(1.05);
+}
+
+.logo-icon {
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    padding: 2px;
+    object-fit: contain;
+}
+
+/* signup-box */
+.signup-box {
+    background-color: #fff;
+    width: 100%;
+    max-width: 900px;
+    padding: 90px 140px;
+    border-radius: 30px;
+    box-shadow: 0 0 20px #85858540;
+    margin-top: 50px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* title */
+.top {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.title {
+    font-size: 24px;
+    font-weight: 600;
+    text-align: left;
+    flex-shrink: 0;
+}
+
+.page-num {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+    color: #777;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.page-num::after {
+    content: '';
+    flex-grow: 1;
+    height: 1px;
+    display: inline-block;
+}
+
+/* 공통 입력 그룹 */
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.form-group label {
+    font-size: 15px;
+    font-weight: 600;
+    color: #222;
+}
+
+.form-group input,
+.form-group select {
+    border: 1px solid #ccc;
+    border-radius: 30px;
+    padding: 12px 14px;
+    font-size: 16px;
+    width: 100%;
+    font-family: inherit;
+}
+
+/* 성별 선택 */
+.gender-group {
+    display: flex;
+    gap: 40px;
+}
+
+.gender-group label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 16px;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+/* 전화번호, 이메일, 인증번호 입력 줄 정렬 */
+.phone-group,
+.email-group,
+.auth-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.phone-group select,
+.email-group select {
+    min-width: 100px;
+}
+
+/* 인증/확인 버튼 */
+.email-group button,
+.auth-group button {
+    height: 42px;
+    padding: 0 16px;
+    font-size: 15px;
+    font-weight: 500;
+    background-color: #3573ee;
+    color: #fff;
+    border: none;
+    border-radius: 30px;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.email-group button:hover,
+.auth-group button:hover {
+    background-color: #255edb;
+}
+
+/* 비밀번호 조건 리스트 */
+.password-rules {
+    margin-top: 6px;
+    font-size: 13px;
+    padding-left: 16px;
+    list-style: disc;
+}
+
+/* 동의 버튼 */
+.agreement {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.agreement-con1 {
+    background-color: #f5f5f5;
+    padding: 16px 24px;
+    border-radius: 14px;
+    font-size: 16px;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+}
+
+.agreement-con1 label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 16px;
+    font-weight: 500;
+}
+
+.agreement-con2 {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 16px 24px;
+}
+
+.agreement-left {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.agreement-item label {
+    font-size: 15px;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.agreement-sub-items {
+    display: flex;
+    gap: 40px;
+    padding-left: 28px;
+    font-size: 14px;
+}
+
+.agreement-sub-items label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.agreement-right button {
+    background: none;
+    border: none;
+    font-size: 22px;
+    cursor: pointer;
+    padding: 0 6px;
+}
+
+.agreement-con2 input[type='checkbox'] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    border: none;
+    background: none;
+    position: relative;
+    cursor: pointer;
+}
+
+/* 항상 체크 아이콘 표시 */
+.agreement-con2 input[type='checkbox']::after {
+    content: '✔';
+    position: absolute;
+    top: 0;
+    left: 0;
+    font-size: 16px;
+    line-height: 1;
+    color: gray; /* 기본 회색 */
+}
+
+/* 체크된 경우 색 변경 */
+.agreement-con2 input[type='checkbox']:checked::after {
+    color: #3573ee; /* 파란색 */
+}
+
+/* 힌트/성공/실패 메시지 */
+.hint {
+    font-size: 13px;
+    color: gray;
+}
+
+.success {
+    font-size: 13px;
+    color: green;
+}
+
+.error {
+    font-size: 13px;
+    color: red;
+}
+
+/* 버튼 하단 */
+.button-group {
+    display: flex;
+    gap: 10px;
+    justify-content: space-between;
+    margin-top: 20px;
+}
+
+.cancel-button {
+    background: #f2f2f2;
+    color: #222;
+    border: none;
+    border-radius: 30px;
+    padding: 14px 24px;
+    font-size: 16px;
+    font-weight: 500;
+    min-width: 200px;
+    cursor: pointer;
+}
+
+.next-button {
+    background: #3573ee;
+    color: white;
+    border: none;
+    border-radius: 30px;
+    padding: 14px 24px;
+    font-size: 16px;
+    font-weight: 500;
+    min-width: 200px;
+    cursor: pointer;
+}
+
+.next-button:disabled {
+    background: #a5c2ff;
+    cursor: not-allowed;
+}
+
+.next-button:hover:enabled {
+    background-color: #255edb;
+}
+
+/* 모바일 대응 */
+@media (max-width: 768px) {
+    .signup-box {
+        padding: 40px 30px;
+        border-radius: 30px;
+    }
+
+    .title {
+        font-size: 22px;
+    }
+
+    .form-group input,
+    .form-group select {
+        font-size: 15px;
+        padding: 10px 12px;
+    }
+
+    .email-group button,
+    .auth-group button,
+    .next-button,
+    .cancel-button {
+        font-size: 14px;
+        padding: 12px 16px;
+    }
+}
+</style>

--- a/frontend/src/pages/auth/SignupStep1Local.vue
+++ b/frontend/src/pages/auth/SignupStep1Local.vue
@@ -1,0 +1,683 @@
+<script setup>
+import { reactive, ref, computed, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import PrivacyPolicyModal from '@/components/PrivacyPolicyModal.vue';
+
+const router = useRouter();
+
+const userInfo = reactive({
+    name: '',
+    gender: '',
+    birth: '',
+    phone1: '',
+    phone2: '',
+    phone3: '',
+    emailId: '',
+    emailDomain: '',
+    emailCode: '',
+    password: '',
+    passwordConfirm: '',
+    agreed: false,
+    agreeSub0: false,
+    agreeSub1: false,
+    agreeSub2: false,
+});
+
+const emailSent = ref(false);
+const emailVerified = ref(false);
+const emailError = ref('');
+const passwordError = ref('');
+const isPolicyModalOpen = ref(false);
+
+// 이메일 인증
+const sendEmailVerification = () => {
+    emailSent.value = true;
+    emailError.value = '';
+};
+
+// 이메일 인증번호 검사
+const confirmEmailCode = () => {
+    emailVerified.value = userInfo.emailCode === '123456';
+    emailError.value = emailVerified.value
+        ? ''
+        : '인증번호가 올바르지 않습니다.';
+};
+
+// 비밀번호 조건 검사
+const passwordConditions = computed(() => {
+    const pw = userInfo.password;
+    return {
+        length: pw.length >= 8,
+        hasLetter: /[a-zA-Z]/.test(pw),
+        hasNumber: /[0-9]/.test(pw),
+        hasSpecial: /[^a-zA-Z0-9]/.test(pw),
+    };
+});
+
+// 실시간 비밀번호 확인 성공 여부 파악
+watch(
+    () => [userInfo.password, userInfo.passwordConfirm],
+    ([pw, pwConfirm]) => {
+        if (!pwConfirm) {
+            passwordError.value = '';
+            return;
+        }
+        passwordError.value =
+            pw !== pwConfirm ? '비밀번호가 일치하지 않습니다.' : '';
+    }
+);
+
+// 비밀번호 확인 성공 여부
+const passwordSuccess = computed(() => {
+    return (
+        userInfo.password &&
+        userInfo.passwordConfirm &&
+        userInfo.password === userInfo.passwordConfirm
+    );
+});
+
+// agreed 변경 시 동기화
+watch(
+    () => userInfo.agreed,
+    (val) => {
+        userInfo.agreeSub0 = val;
+        userInfo.agreeSub1 = val;
+        userInfo.agreeSub2 = val;
+    }
+);
+
+// agreeSub0 변경 시 동기화
+watch(
+    () => userInfo.agreeSub0,
+    (val) => {
+        userInfo.agreed = val;
+        userInfo.agreeSub1 = val;
+        userInfo.agreeSub2 = val;
+    }
+);
+
+// 동의 버튼
+const openModal = () => {
+    isPolicyModalOpen.value = true;
+};
+
+// 모달에서 가져온 값 적용
+const handlePolicyAgree = (agreeData) => {
+    userInfo.agreed = agreeData.agreed;
+    userInfo.agreeSub0 = agreeData.agreeSub0;
+    userInfo.agreeSub1 = agreeData.agreeSub1;
+    userInfo.agreeSub2 = agreeData.agreeSub2;
+    isPolicyModalOpen.value = false;
+};
+
+//
+const isFormValid = computed(() => {
+    return (
+        userInfo.name &&
+        userInfo.gender &&
+        userInfo.birth &&
+        userInfo.phone1 &&
+        userInfo.phone2 &&
+        userInfo.phone3 &&
+        userInfo.emailId &&
+        userInfo.emailDomain &&
+        userInfo.password &&
+        userInfo.passwordConfirm &&
+        userInfo.agreed &&
+        emailVerified.value &&
+        userInfo.password === userInfo.passwordConfirm
+    );
+});
+
+// 다음 페이지
+const goNext = () => {
+    if (!isFormValid.value) return;
+    router.push('/signup/step2'); // 다음 단계로 라우팅
+};
+</script>
+
+<template>
+    <div class="container">
+        <router-link to="/" class="logo-section text-decoration-none">
+            <div class="logo d-flex align-items-center">
+                <img src="@/assets/logo.svg" alt="로고" class="logo-icon" />
+            </div>
+        </router-link>
+
+        <div class="signup-box">
+            <div class="top">
+                <div class="title">
+                    콕재 서비스를 이용하려면<br />회원 가입이 필요해요
+                </div>
+                <div class="page-num">1/3</div>
+            </div>
+
+            <hr />
+
+            <div class="title">개인정보 입력</div>
+
+            <div class="form-group">
+                <label>이름</label>
+                <input
+                    v-model="userInfo.name"
+                    placeholder="이름을 입력하세요"
+                />
+            </div>
+
+            <div class="form-group">
+                <label>성별</label>
+                <div class="gender-group">
+                    <label>
+                        <input
+                            type="radio"
+                            value="M"
+                            v-model="userInfo.gender"
+                        />
+                        남성</label
+                    >
+                    <label>
+                        <input
+                            type="radio"
+                            value="F"
+                            v-model="userInfo.gender"
+                        />
+                        여성</label
+                    >
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label>생년월일</label>
+                <input type="date" v-model="userInfo.birth" />
+            </div>
+
+            <div class="form-group">
+                <label>전화번호</label>
+                <div class="phone-group">
+                    <select v-model="userInfo.phone1">
+                        <option value="">선택</option>
+                        <option value="010">010</option>
+                        <option value="011">011</option>
+                    </select>
+                    <input v-model="userInfo.phone2" maxlength="4" />
+                    <input v-model="userInfo.phone3" maxlength="4" />
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label>이메일</label>
+                <div class="email-group">
+                    <input v-model="userInfo.emailId" />
+                    <span>@</span>
+                    <select v-model="userInfo.emailDomain">
+                        <option value="">선택</option>
+                        <option value="gmail.com">gmail.com</option>
+                        <option value="naver.com">naver.com</option>
+                        <option value="daum.net">daum.net</option>
+                    </select>
+                    <button @click="sendEmailVerification">인증</button>
+                </div>
+                <p v-if="emailSent" class="hint">
+                    이메일로 인증번호가 전송되었습니다.
+                </p>
+            </div>
+
+            <div class="form-group">
+                <label>인증번호</label>
+                <div class="auth-group">
+                    <input v-model="userInfo.emailCode" />
+                    <button @click="confirmEmailCode">확인</button>
+                </div>
+                <p v-if="emailVerified" class="success">이메일 인증 완료</p>
+                <p v-else-if="emailError" class="error">{{ emailError }}</p>
+            </div>
+
+            <div class="form-group">
+                <label>비밀번호</label>
+                <input
+                    type="password"
+                    v-model="userInfo.password"
+                    placeholder="비밀번호 입력"
+                />
+                <ul class="password-rules">
+                    <li :class="passwordConditions.length ? 'success' : 'hint'">
+                        8자 이상
+                    </li>
+                    <li
+                        :class="
+                            passwordConditions.hasLetter ? 'success' : 'hint'
+                        "
+                    >
+                        영문자 포함
+                    </li>
+                    <li
+                        :class="
+                            passwordConditions.hasNumber ? 'success' : 'hint'
+                        "
+                    >
+                        숫자 포함
+                    </li>
+                    <li
+                        :class="
+                            passwordConditions.hasSpecial ? 'success' : 'hint'
+                        "
+                    >
+                        특수문자 포함
+                    </li>
+                </ul>
+            </div>
+
+            <div class="form-group">
+                <label>비밀번호 확인</label>
+                <input
+                    type="password"
+                    v-model="userInfo.passwordConfirm"
+                    placeholder="비밀번호 재입력"
+                />
+                <p class="success" v-if="passwordSuccess">
+                    비밀번호가 일치합니다.
+                </p>
+                <p class="error" v-if="passwordError">{{ passwordError }}</p>
+            </div>
+
+            <hr />
+
+            <div class="agreement">
+                <div class="agreement-con1">
+                    <label>
+                        <input type="checkbox" v-model="userInfo.agreed" />
+                        <strong>[필수] 개인(신용)정보 처리 동의</strong>
+                    </label>
+                </div>
+
+                <div class="agreement-con2">
+                    <div class="agreement-left">
+                        <div class="agreement-item">
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    v-model="userInfo.agreeSub0"
+                                />
+                                개인(신용)정보 수집·이용 동의
+                            </label>
+                        </div>
+                        <div class="agreement-sub-items">
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    v-model="userInfo.agreeSub1"
+                                    disabled
+                                />
+                                고유식별정보
+                            </label>
+                            <label>
+                                <input
+                                    type="checkbox"
+                                    v-model="userInfo.agreeSub2"
+                                    disabled
+                                />
+                                개인(신용)정보
+                            </label>
+                        </div>
+                    </div>
+                    <div class="agreement-right">
+                        <button @click="openModal">＞</button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="button-group">
+                <button class="cancel-button" @click="router.push('/')">
+                    취소하기
+                </button>
+                <button
+                    :disabled="!isFormValid"
+                    class="next-button"
+                    @click="goNext"
+                >
+                    다음 단계
+                </button>
+            </div>
+        </div>
+    </div>
+    <PrivacyPolicyModal
+        v-if="isPolicyModalOpen"
+        @close="isPolicyModalOpen = false"
+        @agree="handlePolicyAgree"
+    />
+</template>
+
+<style scoped>
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
+    padding: 0 16px 40px 16px;
+    position: relative;
+}
+
+/* logo */
+.logo-section {
+    cursor: pointer;
+    margin: 15px 0 0 20px;
+    align-self: flex-start;
+    transition: transform 0.2s ease;
+}
+
+.logo-section:hover {
+    transform: scale(1.05);
+}
+
+.logo-icon {
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    padding: 2px;
+    object-fit: contain;
+}
+
+/* signup-box */
+.signup-box {
+    background-color: #fff;
+    width: 100%;
+    max-width: 900px;
+    padding: 90px 140px;
+    border-radius: 30px;
+    box-shadow: 0 0 20px #85858540;
+    margin-top: 50px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* title */
+.top {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.title {
+    font-size: 24px;
+    font-weight: 600;
+    text-align: left;
+    flex-shrink: 0;
+}
+
+.page-num {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+    color: #777;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.page-num::after {
+    content: '';
+    flex-grow: 1;
+    height: 1px;
+    display: inline-block;
+}
+
+/* 공통 입력 그룹 */
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.form-group label {
+    font-size: 15px;
+    font-weight: 600;
+    color: #222;
+}
+
+.form-group input,
+.form-group select {
+    border: 1px solid #ccc;
+    border-radius: 30px;
+    padding: 12px 14px;
+    font-size: 16px;
+    width: 100%;
+    font-family: inherit;
+}
+
+/* 성별 선택 */
+.gender-group {
+    display: flex;
+    gap: 40px;
+}
+
+.gender-group label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 16px;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+/* 전화번호, 이메일, 인증번호 입력 줄 정렬 */
+.phone-group,
+.email-group,
+.auth-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.phone-group select,
+.email-group select {
+    min-width: 100px;
+}
+
+/* 인증/확인 버튼 */
+.email-group button,
+.auth-group button {
+    height: 42px;
+    padding: 0 16px;
+    font-size: 15px;
+    font-weight: 500;
+    background-color: #3573ee;
+    color: #fff;
+    border: none;
+    border-radius: 30px;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.email-group button:hover,
+.auth-group button:hover {
+    background-color: #255edb;
+}
+
+/* 비밀번호 조건 리스트 */
+.password-rules {
+    margin-top: 6px;
+    font-size: 13px;
+    padding-left: 16px;
+    list-style: disc;
+}
+
+/* 동의 버튼 */
+.agreement {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.agreement-con1 {
+    background-color: #f5f5f5;
+    padding: 16px 24px;
+    border-radius: 14px;
+    font-size: 16px;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+}
+
+.agreement-con1 label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 16px;
+    font-weight: 500;
+}
+
+.agreement-con2 {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    padding: 16px 24px;
+}
+
+.agreement-left {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.agreement-item label {
+    font-size: 15px;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.agreement-sub-items {
+    display: flex;
+    gap: 40px;
+    padding-left: 28px;
+    font-size: 14px;
+}
+
+.agreement-sub-items label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.agreement-right button {
+    background: none;
+    border: none;
+    font-size: 22px;
+    cursor: pointer;
+    padding: 0 6px;
+}
+
+.agreement-con2 input[type='checkbox'] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    border: none;
+    background: none;
+    position: relative;
+    cursor: pointer;
+}
+
+/* 항상 체크 아이콘 표시 */
+.agreement-con2 input[type='checkbox']::after {
+    content: '✔';
+    position: absolute;
+    top: 0;
+    left: 0;
+    font-size: 16px;
+    line-height: 1;
+    color: gray; /* 기본 회색 */
+}
+
+/* 체크된 경우 색 변경 */
+.agreement-con2 input[type='checkbox']:checked::after {
+    color: #3573ee; /* 파란색 */
+}
+
+/* 힌트/성공/실패 메시지 */
+.hint {
+    font-size: 13px;
+    color: gray;
+}
+
+.success {
+    font-size: 13px;
+    color: green;
+}
+
+.error {
+    font-size: 13px;
+    color: red;
+}
+
+/* 버튼 하단 */
+.button-group {
+    display: flex;
+    gap: 10px;
+    justify-content: space-between;
+    margin-top: 20px;
+}
+
+.cancel-button {
+    background: #f2f2f2;
+    color: #222;
+    border: none;
+    border-radius: 30px;
+    padding: 14px 24px;
+    font-size: 16px;
+    font-weight: 500;
+    min-width: 200px;
+    cursor: pointer;
+}
+
+.next-button {
+    background: #3573ee;
+    color: white;
+    border: none;
+    border-radius: 30px;
+    padding: 14px 24px;
+    font-size: 16px;
+    font-weight: 500;
+    min-width: 200px;
+    cursor: pointer;
+}
+
+.next-button:disabled {
+    background: #a5c2ff;
+    cursor: not-allowed;
+}
+
+.next-button:hover:enabled {
+    background-color: #255edb;
+}
+
+/* 모바일 대응 */
+@media (max-width: 768px) {
+    .signup-box {
+        padding: 40px 30px;
+        border-radius: 30px;
+    }
+
+    .title {
+        font-size: 22px;
+    }
+
+    .form-group input,
+    .form-group select {
+        font-size: 15px;
+        padding: 10px 12px;
+    }
+
+    .email-group button,
+    .auth-group button,
+    .next-button,
+    .cancel-button {
+        font-size: 14px;
+        padding: 12px 16px;
+    }
+}
+</style>

--- a/frontend/src/router/auth.js
+++ b/frontend/src/router/auth.js
@@ -4,4 +4,9 @@ export default [
         name: 'login',
         component: () => import('../pages/auth/LoginPage.vue'),
     },
+    {
+        path: '/signup/step1/local',
+        name: 'signup-step1-local',
+        component: () => import('../pages/auth/SignupStep1Local.vue'),
+    },
 ];

--- a/frontend/src/router/auth.js
+++ b/frontend/src/router/auth.js
@@ -9,4 +9,9 @@ export default [
         name: 'signup-step1-local',
         component: () => import('../pages/auth/SignupStep1Local.vue'),
     },
+    {
+        path: '/signup/step1/kakao',
+        name: 'signup-step1-kakao',
+        component: () => import('../pages/auth/SignupStep1Kakao.vue'),
+    },
 ];


### PR DESCRIPTION
## 📌 Issues
- closed #30 

## 🏁 Work Description
- 회원가입 1단계 로컬 페이지(SignupStep1Local.vue) 구현
- 회원가입 1단계 카카오 페이지(SignupStep1Kakao.vue) 구현
- 개인(신용)정보 동의 팝업 모달(PrivacyPolicyModal.vue) 연동 및 로직 구현

## 💬 PR Points
- 어떤 부분을 리뷰어가 중점적으로 보아야 하는지
- 우려사항 등

## 📷 Screenshot
<img width="1624" height="979" alt="스크린샷 2025-07-28 오후 5 31 08" src="https://github.com/user-attachments/assets/d96168fd-3029-44bb-a274-beff33516e07" />
<img width="1624" height="979" alt="스크린샷 2025-07-28 오후 5 31 28" src="https://github.com/user-attachments/assets/3f9d4c73-3351-4993-934a-584627c45a6c" />
<img width="1624" height="979" alt="스크린샷 2025-07-28 오후 5 31 36" src="https://github.com/user-attachments/assets/75ce777c-d859-4cd8-a499-4b7fc6335d21" />

<img width="1624" height="979" alt="스크린샷 2025-07-28 오후 5 31 50" src="https://github.com/user-attachments/assets/b32d9104-baa3-4ad7-bc34-b5b97c9edb0f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new signup step pages for both local and Kakao users, including detailed forms and privacy policy agreement modals.
  * Introduced a modal for privacy policy consent with clear options to agree or reject.
  * Enabled navigation from the login page to the new signup process.

* **Style**
  * Applied a new global font and updated font-face declarations for improved visual consistency.
  * Enhanced and standardized form and modal styling for a better user experience.

* **Bug Fixes**
  * Adjusted header and footer visibility to properly hide them on new signup step pages.

* **Chores**
  * Added new routes for the local and Kakao signup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->