### PR TITLE
Feature/#36 회원가입 2단계 UI 구현

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,6 +11,7 @@ const pagesWithoutHeaderFooter = [
     '/auth/login',
     '/signup/step1/local',
     '/signup/step1/kakao',
+    '/signup/step2',
 ];
 
 const showHeaderFooter = computed(() => {

--- a/frontend/src/pages/auth/SignupStep1Kakao.vue
+++ b/frontend/src/pages/auth/SignupStep1Kakao.vue
@@ -5,16 +5,30 @@ import PrivacyPolicyModal from '@/components/PrivacyPolicyModal.vue';
 
 const router = useRouter();
 
+// // 실제 사용
+// const userInfo = reactive({
+//     gender: '',
+//     birth: '',
+//     phone1: '',
+//     phone2: '',
+//     phone3: '',
+//     agreed: false,
+//     agreeSub0: false,
+//     agreeSub1: false,
+//     agreeSub2: false,
+// });
+
+// 테스트 용
 const userInfo = reactive({
-    gender: '',
-    birth: '',
-    phone1: '',
-    phone2: '',
-    phone3: '',
-    agreed: false,
-    agreeSub0: false,
-    agreeSub1: false,
-    agreeSub2: false,
+    gender: 'F',
+    birth: '1992-07-15',
+    phone1: '010',
+    phone2: '9876',
+    phone3: '4321',
+    agreed: true,
+    agreeSub0: true,
+    agreeSub1: true,
+    agreeSub2: true,
 });
 
 const isPolicyModalOpen = ref(false);

--- a/frontend/src/pages/auth/SignupStep1Local.vue
+++ b/frontend/src/pages/auth/SignupStep1Local.vue
@@ -5,40 +5,66 @@ import PrivacyPolicyModal from '@/components/PrivacyPolicyModal.vue';
 
 const router = useRouter();
 
+// // 실제 사용
+// const userInfo = reactive({
+//     name: '',
+//     gender: '',
+//     birth: '',
+//     phone1: '',
+//     phone2: '',
+//     phone3: '',
+//     emailId: '',
+//     emailDomain: '',
+//     emailCode: '',
+//     password: '',
+//     passwordConfirm: '',
+//     agreed: false,
+//     agreeSub0: false,
+//     agreeSub1: false,
+//     agreeSub2: false,
+// });
+
+// 테스트 용
 const userInfo = reactive({
-    name: '',
-    gender: '',
-    birth: '',
-    phone1: '',
-    phone2: '',
-    phone3: '',
-    emailId: '',
-    emailDomain: '',
-    emailCode: '',
-    password: '',
-    passwordConfirm: '',
-    agreed: false,
-    agreeSub0: false,
-    agreeSub1: false,
-    agreeSub2: false,
+    name: '홍길동',
+    gender: 'M',
+    birth: '1995-01-01',
+    phone1: '010',
+    phone2: '1234',
+    phone3: '5678',
+    emailId: 'testuser',
+    emailDomain: 'gmail.com',
+    emailCode: '123456',
+    password: 'Test@1234',
+    passwordConfirm: 'Test@1234',
+    agreed: true,
+    agreeSub0: true,
+    agreeSub1: true,
+    agreeSub2: true,
 });
 
 const emailSent = ref(false);
+const emailSentError = ref('');
 const emailVerified = ref(false);
-const emailError = ref('');
+const emailVerifiedError = ref('');
 const passwordError = ref('');
 const isPolicyModalOpen = ref(false);
 
 // 이메일 인증
 const sendEmailVerification = () => {
+    if (!userInfo.emailId || !userInfo.emailDomain) {
+        emailSentError.value = '이메일을 정확히 입력해주세요.';
+        return;
+    }
+
     emailSent.value = true;
-    emailError.value = '';
+    emailSentError.value = ''; // 오류 메시지 초기화
 };
 
 // 이메일 인증번호 검사
 const confirmEmailCode = () => {
     emailVerified.value = userInfo.emailCode === '123456';
-    emailError.value = emailVerified.value
+    emailVerifiedError.value = emailVerified.value
         ? ''
         : '인증번호가 올바르지 않습니다.';
 };
@@ -220,6 +246,9 @@ const goNext = () => {
                 <p v-if="emailSent" class="hint">
                     이메일로 인증번호가 전송되었습니다.
                 </p>
+                <p v-else-if="emailSentError" class="error">
+                    {{ emailSentError }}
+                </p>
             </div>
 
             <div class="form-group">
@@ -229,7 +258,9 @@ const goNext = () => {
                     <button @click="confirmEmailCode">확인</button>
                 </div>
                 <p v-if="emailVerified" class="success">이메일 인증 완료</p>
-                <p v-else-if="emailError" class="error">{{ emailError }}</p>
+                <p v-else-if="emailVerifiedError" class="error">
+                    {{ emailVerifiedError }}
+                </p>
             </div>
 
             <div class="form-group">

--- a/frontend/src/pages/auth/SignupStep2.vue
+++ b/frontend/src/pages/auth/SignupStep2.vue
@@ -1,0 +1,368 @@
+<script setup>
+import { reactive, computed } from 'vue';
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+
+const assetInfo = reactive({
+    monthlyIncomeRaw: '',
+    monthlyExpenseRaw: '',
+});
+
+// 숫자만 추출
+const unformat = (value) => value.replace(/,/g, '').replace(/\D/g, '');
+
+// 3자리마다 콤마 찍기
+const format = (value) => {
+    const num = unformat(value);
+    if (!num) return '';
+    return Number(num).toLocaleString();
+};
+
+// 입력된 문자열에서 숫자만 추출한 후 정수(Number)로 변환
+const getRawNumber = (value) => {
+    const raw = unformat(value);
+    return raw === '' ? 0 : parseInt(raw);
+};
+
+// 금액 → 한국어 단위 변환
+function numberToKorean(num) {
+    const units = ['', '만', '억', '조'];
+    const result = [];
+
+    let strNum = String(num);
+    let i = 0;
+
+    while (strNum.length > 0) {
+        const chunk = strNum.length >= 4 ? strNum.slice(-4) : strNum;
+        strNum = strNum.slice(0, -4);
+
+        if (Number(chunk) !== 0) {
+            result.unshift(`${Number(chunk)}${units[i]}`);
+        }
+        i++;
+    }
+    return result.length > 0 ? result.join(' ') + ' 원' : ' 원';
+}
+
+// 포맷팅된 v-model
+const monthlyIncome = computed({
+    get: () => format(assetInfo.monthlyIncomeRaw),
+    set: (val) => (assetInfo.monthlyIncomeRaw = unformat(val)),
+});
+
+const monthlyExpense = computed({
+    get: () => format(assetInfo.monthlyExpenseRaw),
+    set: (val) => (assetInfo.monthlyExpenseRaw = unformat(val)),
+});
+
+// 한글 시각화
+const koreanIncome = computed(() =>
+    numberToKorean(getRawNumber(monthlyIncome.value))
+);
+
+const koreanExpense = computed(() =>
+    numberToKorean(getRawNumber(monthlyExpense.value))
+);
+
+// 입력 초기화
+const resetField = (type) => {
+    if (type === 'income') assetInfo.monthlyIncomeRaw = '';
+    if (type === 'expense') assetInfo.monthlyExpenseRaw = '';
+};
+
+// 유효성 검사
+const isFormValid = computed(
+    () =>
+        assetInfo.monthlyIncomeRaw !== '' && assetInfo.monthlyExpenseRaw !== ''
+);
+
+// 다음 페이지
+const goNext = () => {
+    if (!isFormValid.value) return;
+
+    const data = {
+        income: Number(assetInfo.monthlyIncomeRaw),
+        expense: Number(assetInfo.monthlyExpenseRaw),
+    };
+
+    console.log('제출 데이터:', data);
+    router.push('/signup/step3');
+};
+</script>
+
+<template>
+    <div class="container">
+        <router-link to="/" class="logo-section text-decoration-none">
+            <div class="logo d-flex align-items-center">
+                <img src="@/assets/logo.svg" alt="로고" class="logo-icon" />
+            </div>
+        </router-link>
+
+        <div class="signup-box">
+            <div class="top">
+                <div class="title">
+                    콕재 서비스를 이용하려면<br />회원 가입이 필요해요
+                </div>
+                <div class="page-num">2/3</div>
+            </div>
+
+            <hr />
+
+            <div class="title">자산정보 입력</div>
+
+            <div class="form-group with-unit">
+                <label>월 소득 (원)</label>
+                <div class="input-with-unit">
+                    <input
+                        type="text"
+                        v-model="monthlyIncome"
+                        placeholder="금액을 입력해주세요"
+                    />
+                    <button
+                        class="reset-btn"
+                        v-if="monthlyIncome"
+                        @click="resetField('income')"
+                    >
+                        ×
+                    </button>
+                    <span class="unit">원</span>
+                </div>
+                <div class="visual-display">{{ koreanIncome }}</div>
+            </div>
+
+            <div class="form-group with-unit">
+                <label>월 지출 (원)</label>
+                <div class="input-with-unit">
+                    <input
+                        type="text"
+                        v-model="monthlyExpense"
+                        placeholder="금액을 입력해주세요"
+                    />
+                    <button
+                        class="reset-btn"
+                        v-if="monthlyExpense"
+                        @click="resetField('expense')"
+                    >
+                        ×
+                    </button>
+                    <span class="unit">원</span>
+                </div>
+                <div class="visual-display">{{ koreanExpense }}</div>
+            </div>
+
+            <div class="button-group">
+                <button
+                    class="cancel-button"
+                    @click="router.push('/signup/step1')"
+                >
+                    뒤로가기
+                </button>
+                <button
+                    :disabled="!isFormValid"
+                    class="next-button"
+                    @click="goNext"
+                >
+                    다음 단계
+                </button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-height: 100vh;
+    padding: 0 16px 40px 16px;
+    position: relative;
+}
+
+/* logo */
+.logo-section {
+    cursor: pointer;
+    margin: 15px 0 0 20px;
+    align-self: flex-start;
+    transition: transform 0.2s ease;
+}
+
+.logo-section:hover {
+    transform: scale(1.05);
+}
+
+.logo-icon {
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    padding: 2px;
+    object-fit: contain;
+}
+
+/* signup-box */
+.signup-box {
+    background-color: #fff;
+    width: 100%;
+    max-width: 900px;
+    padding: 90px 140px;
+    border-radius: 30px;
+    box-shadow: 0 0 20px #85858540;
+    margin-top: 50px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* title */
+.top {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.title {
+    font-size: 24px;
+    font-weight: 600;
+    text-align: left;
+    flex-shrink: 0;
+}
+
+.page-num {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+    color: #777;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.page-num::after {
+    content: '';
+    flex-grow: 1;
+    height: 1px;
+    display: inline-block;
+}
+
+/* 공통 입력 그룹 */
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.form-group label {
+    font-size: 15px;
+    font-weight: 600;
+    color: #222;
+}
+
+/* input + 단위 + X 버튼 */
+.input-with-unit {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    position: relative;
+}
+
+.input-with-unit input {
+    flex: 1;
+    font-size: 16px;
+    padding: 12px 14px;
+    border: 1px solid #ccc;
+    border-radius: 30px;
+}
+
+.input-with-unit input::-webkit-outer-spin-button,
+.input-with-unit input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.unit {
+    font-size: 16px;
+    color: #222;
+}
+
+.reset-btn {
+    position: absolute;
+    right: 40px;
+    background: none;
+    border: none;
+    font-size: 20px;
+    color: #888;
+    cursor: pointer;
+}
+
+.visual-display {
+    margin-top: 4px;
+    color: #777;
+    font-size: 14px;
+}
+
+/* 버튼 하단 */
+.button-group {
+    display: flex;
+    gap: 10px;
+    justify-content: space-between;
+    margin-top: 20px;
+}
+
+.cancel-button {
+    background: #f2f2f2;
+    color: #222;
+    border: none;
+    border-radius: 30px;
+    padding: 14px 24px;
+    font-size: 16px;
+    font-weight: 500;
+    min-width: 200px;
+    cursor: pointer;
+}
+
+.next-button {
+    background: #3573ee;
+    color: white;
+    border: none;
+    border-radius: 30px;
+    padding: 14px 24px;
+    font-size: 16px;
+    font-weight: 500;
+    min-width: 200px;
+    cursor: pointer;
+}
+
+.next-button:disabled {
+    background: #a5c2ff;
+    cursor: not-allowed;
+}
+
+.next-button:hover:enabled {
+    background-color: #255edb;
+}
+
+/* 모바일 대응 관련 */
+@media (max-width: 768px) {
+    .signup-box {
+        padding: 40px 30px;
+        border-radius: 30px;
+    }
+
+    .title {
+        font-size: 22px;
+    }
+
+    .form-group input {
+        font-size: 15px;
+        padding: 10px 12px;
+    }
+
+    .next-button,
+    .cancel-button {
+        font-size: 14px;
+        padding: 12px 16px;
+    }
+}
+</style>

--- a/frontend/src/router/auth.js
+++ b/frontend/src/router/auth.js
@@ -14,4 +14,9 @@ export default [
         name: 'signup-step1-kakao',
         component: () => import('../pages/auth/SignupStep1Kakao.vue'),
     },
+    {
+        path: '/signup/step2',
+        name: 'signup-step2',
+        component: () => import('../pages/auth/SignupStep2.vue'),
+    },
 ];


### PR DESCRIPTION
회원가입 2단계 UI 구현

## 📌 Issues
- closed #36 

## 🏁 Work Description
- 회원가입 2단계 페이지(SignupStep2.vue) 구현
- 월 소득 / 월 지출 입력 필드 구현 (입력 시 콤마 포맷팅 적용)
- 입력값 초기화를 위한 X 버튼 추가
- 입력값 하단에 한국어 금액 단위(예: "1억 2,345만 원") 시각화 추가
- 입력값 우측 ‘원’ 단위 표기를 input 외부 우측에 고정 배치
- 입력값 유효성 검사 및 ‘다음 단계’ 버튼 활성화 조건 구현

## 💬 PR Points
- 어떤 부분을 리뷰어가 중점적으로 보아야 하는지
- 우려사항 등

## 📷 Screenshot
<img width="1580" height="938" alt="스크린샷 2025-07-29 오전 11 04 26" src="https://github.com/user-attachments/assets/da0171c5-c07f-4f2b-a69a-829d9976219b" />
<img width="1624" height="982" alt="스크린샷 2025-07-29 오전 11 04 56" src="https://github.com/user-attachments/assets/b9ec7746-25d6-4ec2-b992-0e22df331767" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new signup step for collecting monthly income and expense, featuring formatted input fields and Korean currency unit display.
  * Added navigation for the new signup step in the app’s routing.

* **Improvements**
  * Enhanced error handling and user feedback during email verification in the signup process.
  * Updated signup forms to use pre-filled test data for easier testing.

* **UI Updates**
  * The header and footer are now hidden on the new signup step for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->