### PR TITLE
Feature: 금융상품추천 페이지 반응형 구현 및 스타일 수정

### DIFF
--- a/frontend/src/components/homePage/HomeToGoalComponent.vue
+++ b/frontend/src/components/homePage/HomeToGoalComponent.vue
@@ -5,7 +5,7 @@
       <h3 class="card-title">목표</h3>
     </div>
     <div class="card-content">
-      <img src="@/assets/images/goal_logo.svg" alt="목표 로고" class="logo" />
+      <img src="@/assets/images/goal_logo.svg" alt="목표 로고" />
     </div>
   </div>
 </template>

--- a/frontend/src/components/homePage/HomeToProductComponent.vue
+++ b/frontend/src/components/homePage/HomeToProductComponent.vue
@@ -5,7 +5,7 @@
       <h3 class="card-title">금융 상품 추천</h3>
     </div>
     <div class="card-content">
-      <img src="@/assets/images/product_recommand_logo.svg" alt="금융 상품 로고" class="logo" />
+      <img src="@/assets/images/product_recommand_logo.svg" alt="금융 상품 로고" />
     </div>
   </div>
 </template>

--- a/frontend/src/components/homePage/HomeToTaxComponent.vue
+++ b/frontend/src/components/homePage/HomeToTaxComponent.vue
@@ -5,7 +5,7 @@
       <h3 class="card-title">세금 관리</h3>
     </div>
     <div class="card-content">
-      <img src="@/assets/images/duty_logo.svg" alt="세금 관리 로고" class="logo" />
+      <img src="@/assets/images/duty_logo.svg" alt="세금 관리 로고" />
     </div>
   </div>
 </template>

--- a/frontend/src/components/layouts/ScrollTopButton.vue
+++ b/frontend/src/components/layouts/ScrollTopButton.vue
@@ -1,0 +1,77 @@
+<template>
+  <!-- ScrollToTop 버튼 -->
+  <div class="scroll-top-btn" @click="scrollToTop">
+    <div class="scroll-top-icon">
+      <i class="fa-solid fa-chevron-up" style="color: #3573ee"></i>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const scrollToTop = () => {
+  window.scrollTo({
+    top: 0,
+    behavior: 'smooth',
+  });
+};
+</script>
+
+<style scoped>
+/* ===== ScrollToTop 버튼 ===== */
+.scroll-top-btn {
+  cursor: pointer;
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  width: 56px;
+  height: 56px;
+  background-color: #ffffff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  color: #374151;
+  border: 2px solid #e5e7eb;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition: all 0.3s ease;
+}
+
+.scroll-top-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+
+.scroll-top-icon {
+  font-size: 20px;
+  transition: transform 0.3s ease;
+}
+
+.scroll-top-btn:hover .scroll-top-icon {
+  transform: translateY(-2px);
+}
+
+@media (max-width: 1024px) {
+  .scroll-top-btn {
+    width: 52px;
+    height: 52px;
+    bottom: 25px;
+    right: 25px;
+  }
+}
+
+@media (max-width: 768px) {
+  /* 스크롤 버튼 */
+  .scroll-top-btn {
+    width: 48px;
+    height: 48px;
+    bottom: 20px;
+    right: 20px;
+  }
+
+  .scroll-top-icon {
+    font-size: 18px;
+  }
+}
+</style>

--- a/frontend/src/components/product/ProductCarousel.vue
+++ b/frontend/src/components/product/ProductCarousel.vue
@@ -16,22 +16,18 @@ const products = ref([]);
 
 const auth = userAuthStore();
 const userId = auth.state.user.userId;
+const userName = auth.state.user.userName || '김콕재';
 
 const iconModules = import.meta.glob('@/assets/images/bankIcon/*.png', {
   eager: true,
   import: 'default',
 });
-const defaultIcon = new URL(
-  '@/assets/images/bankIcon/default.png',
-  import.meta.url
-).href;
+const defaultIcon = new URL('@/assets/images/bankIcon/default.png', import.meta.url).href;
 
 const getBankIcon = (bankName) => {
   const english = bankNameMap[bankName];
   if (!english) return defaultIcon;
-  const match = Object.entries(iconModules).find(([path]) =>
-    path.includes(`/${english}.png`)
-  );
+  const match = Object.entries(iconModules).find(([path]) => path.includes(`/${english}.png`));
   return match ? match[1] : defaultIcon;
 };
 
@@ -64,15 +60,11 @@ function nextSlide() {
 
 <template>
   <div class="carousel-wrapper">
-    <div class="title">✨ 김국제님의 맞춤 추천 상품 ✨</div>
+    <div class="title">✨ {{ userName }}님의 맞춤 추천 상품 ✨</div>
 
     <div class="carousel-container">
-      <button
-        class="nav-button"
-        @click="prevSlide"
-        :disabled="currentPage === 0"
-      >
-        &lt;
+      <button class="nav-button" @click="prevSlide" :disabled="currentPage === 0">
+        <i class="fa-solid fa-angle-left"></i>
       </button>
 
       <div class="carousel-cards">
@@ -81,14 +73,9 @@ function nextSlide() {
           v-for="product in visibleProducts"
           :key="product.finPrdtCd"
           @click="goToDetail(product.finPrdtCd)"
-          style="cursor: pointer"
         >
           <div class="card-header">
-            <img
-              :src="getBankIcon(product.bankName)"
-              alt="은행 로고"
-              class="bank-icon"
-            />
+            <img :src="getBankIcon(product.bankName)" alt="은행 로고" class="bank-icon" />
             <div>
               <div class="product-name">
                 {{ product.productName }}
@@ -96,16 +83,13 @@ function nextSlide() {
               <div class="bank-name">{{ product.bankName }}</div>
             </div>
           </div>
-          <div class="rate">
-            최고 {{ product.intrRate2 }}% / 기본 {{ product.intrRate }}% (12개월
-            세전)
-          </div>
+          <div class="rate">최고 {{ product.intrRate2 }}% / 기본 {{ product.intrRate }}% (12개월 세전)</div>
           <div class="highlight">✨ {{ product.reason }} ✨</div>
         </div>
       </div>
 
       <button class="nav-button" @click="nextSlide" :disabled="endOfSlide">
-        &gt;
+        <i class="fa-solid fa-angle-right"></i>
       </button>
     </div>
   </div>
@@ -113,18 +97,19 @@ function nextSlide() {
 
 <style scoped>
 .carousel-wrapper {
-  background: white;
-  padding: 2rem;
-  border-radius: 1.5rem;
+  height: 360px;
+  background: transparent;
+  padding: 48px 0 36px;
+  border-radius: 20px;
   box-shadow: inset 0 0 12px #3573ee;
   text-align: center;
-  margin-bottom: 2rem;
+  margin: 0 0 36px;
 }
 
 .title {
   font-weight: bold;
   font-size: 1.2rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 50px;
 }
 
 .carousel-container {
@@ -141,17 +126,22 @@ function nextSlide() {
   width: 40px;
   height: 40px;
   font-weight: bold;
-  font-size: 1.2rem;
+  font-size: 20px;
   border-radius: 50%;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   transition: all 0.2s;
 }
 .nav-button:disabled {
   opacity: 0.3;
   cursor: not-allowed;
+}
+.nav-button:hover {
+  cursor: pointer;
+  transform: translateY(-2px);
+  transition: all 0.2s ease;
 }
 
 /* 금융 상품 */
@@ -161,13 +151,19 @@ function nextSlide() {
 }
 
 .card {
-  width: 350px;
+  width: 320px;
   background: white;
   border: 1px solid #ddd;
-  border-radius: 1rem;
+  border-radius: 12px;
   padding: 1.5rem 1.5rem 1.8rem;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.08);
   text-align: left;
+}
+
+.card:hover {
+  cursor: pointer;
+  transform: translateY(-2px);
+  transition: all 0.2s ease;
 }
 
 .card-header {
@@ -188,11 +184,11 @@ function nextSlide() {
 
 .product-name {
   font-weight: bold;
-  font-size: 1.2rem;
+  font-size: 18px;
 }
 
 .bank-name {
-  font-size: 0.85rem;
+  font-size: 13px;
   color: #666;
   margin-top: 0.2rem;
 }
@@ -201,13 +197,52 @@ function nextSlide() {
   margin: 0.5rem 0 1rem;
   font-weight: normal;
   color: #222;
-  font-size: 0.95rem;
+  font-size: 15px;
+  text-align: center;
 }
 
 .highlight {
   list-style: none;
-  padding-left: 0.5rem;
   margin: 0;
   font-weight: bold;
+  font-size: 15px;
+  text-align: center;
+}
+
+@media (max-width: 1024px) {
+  .carousel-wrapper {
+    padding: 36px 36px 36px;
+    margin-bottom: 24px;
+    height: auto;
+  }
+
+  .title {
+    margin-bottom: 36px;
+  }
+
+  .card {
+    width: 230px;
+  }
+
+  .product-name {
+    font-size: 12px;
+  }
+
+  .bank-name {
+    font-size: 10px;
+  }
+
+  .rate {
+    font-size: 10px;
+  }
+  .highlight {
+    font-size: 10px;
+  }
+
+  .nav-button {
+    width: 30px;
+    height: 30px;
+    font-size: 16px;
+  }
 }
 </style>

--- a/frontend/src/components/product/ProductFilterBar.vue
+++ b/frontend/src/components/product/ProductFilterBar.vue
@@ -114,9 +114,7 @@ const chips = computed(() => {
 function removeChip(chip) {
   const f = localFilters.value;
   f.banks = f.banks.filter((b) => b !== chip);
-  const periodKey = Object.entries(periodMap).find(
-    ([, label]) => label === chip
-  )?.[0];
+  const periodKey = Object.entries(periodMap).find(([, label]) => label === chip)?.[0];
   if (periodKey) f.period = 0;
   if (chip === formatKoreanCurrency(Number(f.amount))) f.amount = '';
   f.type = f.type.filter((t) => t !== chip);
@@ -151,7 +149,7 @@ function resetFilters() {
         :class="['filter-toggle', { active: activeFilter === 'period' }]"
       >
         기간·금액
-        <span>{{ activeFilter === 'period' ? '▲' : '▼' }}</span>
+        <span><i :class="activeFilter === 'period' ? 'fa-solid fa-angle-up' : 'fa-solid fa-angle-down'"></i></span>
       </button>
       <button
         @click="
@@ -160,7 +158,8 @@ function resetFilters() {
         "
         :class="['filter-toggle', { active: activeFilter === 'type' }]"
       >
-        상품유형 <span>{{ activeFilter === 'type' ? '▲' : '▼' }}</span>
+        상품유형
+        <span><i :class="activeFilter === 'type' ? 'fa-solid fa-angle-up' : 'fa-solid fa-angle-down'"></i></span>
       </button>
       <button
         @click="
@@ -170,8 +169,9 @@ function resetFilters() {
         :class="['filter-toggle', { active: activeFilter === 'condition' }]"
       >
         우대조건
-        <span>{{ activeFilter === 'condition' ? '▲' : '▼' }}</span>
+        <span><i :class="activeFilter === 'condition' ? 'fa-solid fa-angle-up' : 'fa-solid fa-angle-down'"></i></span>
       </button>
+      <button @click="resetFilters" class="reset-btn">필터 초기화</button>
     </div>
 
     <!-- 세부 필터 -->
@@ -188,13 +188,9 @@ function resetFilters() {
         <TypeFilter v-model="localFilters.type" @change="emitFilterDto" />
       </div>
       <div v-if="activeFilter === 'condition'" class="dropdown-panel">
-        <ConditionFilter
-          v-model="localFilters.conditions"
-          @change="emitFilterDto"
-        />
+        <ConditionFilter v-model="localFilters.conditions" @change="emitFilterDto" />
       </div>
     </div>
-
     <hr />
 
     <!-- 필터 chips -->
@@ -204,20 +200,17 @@ function resetFilters() {
         <button @click="removeChip(chip)">×</button>
       </span>
     </div>
-    <div style="margin-top: 1rem">
-      <button @click="resetFilters" class="reset-btn">필터 초기화</button>
-    </div>
   </div>
 </template>
 
 <style scoped>
 .filter-bar-wrapper {
-  background: white;
-  padding: 2rem;
-  border-radius: 1.5rem;
-  box-shadow: inset 0 0 12px #ddd;
+  background: #ffffff;
+  padding: 32px;
+  border-radius: 20px;
+  box-shadow: inset 0 0 12px #3573ee;
   text-align: center;
-  margin-bottom: 2rem;
+  margin-bottom: 32px;
 }
 
 .filter-toggle-row {
@@ -229,8 +222,8 @@ function resetFilters() {
 
 .filter-toggle {
   border: 1px solid #ccc;
-  border-radius: 2rem;
-  padding: 0.6rem 1rem;
+  border-radius: 20px;
+  padding: 5px 12px;
   background: white;
   font-weight: 600;
   cursor: pointer;
@@ -261,7 +254,7 @@ function resetFilters() {
 }
 
 .chip {
-  background: #316be7;
+  background: #0d3a95;
   color: white;
   padding: 0.4rem 0.8rem;
   border-radius: 2rem;
@@ -275,11 +268,50 @@ function resetFilters() {
   cursor: pointer;
 }
 .reset-btn {
-  padding: 0.5rem 1rem;
-  background: #e0e0e0;
+  padding: 5px 12px;
+  background: #ef4444;
+  color: #ffffff;
   border: none;
-  border-radius: 1rem;
-  cursor: pointer;
+  border-radius: 20px;
   font-weight: 600;
+  transition: all 0.2s ease;
+}
+.reset-btn:hover {
+  cursor: pointer;
+}
+.reset-btn:active {
+  background: #b91c1c; /* 누르고 있을 때 더욱 진한 빨강 */
+}
+
+@media (max-width: 1024px) {
+  .filter-bar-wrapper {
+    margin: 0 0 24px;
+  }
+
+  .filter-toggle {
+    font-size: 13px;
+  }
+
+  .reset-btn {
+    font-size: 13px;
+  }
+
+  .chip {
+    font-size: 13px;
+  }
+}
+
+@media (max-width: 768px) {
+  .filter-toggle {
+    font-size: 12px;
+  }
+
+  .reset-btn {
+    font-size: 12px;
+  }
+
+  .chip {
+    font-size: 12px;
+  }
 }
 </style>

--- a/frontend/src/components/product/ProductList.vue
+++ b/frontend/src/components/product/ProductList.vue
@@ -68,25 +68,18 @@ const iconModules = import.meta.glob('@/assets/images/bankIcon/*.png', {
   eager: true,
   import: 'default',
 });
-const defaultIcon = new URL(
-  '@/assets/images/bankIcon/default.png',
-  import.meta.url
-).href;
+const defaultIcon = new URL('@/assets/images/bankIcon/default.png', import.meta.url).href;
 const getBankIcon = (bankName) => {
   const english = bankNameMap[bankName];
   if (!english) return defaultIcon;
-  const match = Object.entries(iconModules).find(([path]) =>
-    path.includes(`/${english}.png`)
-  );
+  const match = Object.entries(iconModules).find(([path]) => path.includes(`/${english}.png`));
   return match ? match[1] : defaultIcon;
 };
 
 // 🔽 정렬
 const sortedProducts = computed(() => {
   return [...products.value].sort((a, b) =>
-    sortKey.value === 'max'
-      ? b.intrRate2 - a.intrRate2
-      : b.intrRate - a.intrRate
+    sortKey.value === 'max' ? b.intrRate2 - a.intrRate2 : b.intrRate - a.intrRate
   );
 });
 
@@ -120,13 +113,7 @@ function handlePageChange(page) {
 
     <hr />
 
-    <div
-      v-for="product in sortedProducts"
-      :key="product.finPrdtCd"
-      class="product"
-      @click="goToDetail(product)"
-      style="cursor: pointer"
-    >
+    <div v-for="product in sortedProducts" :key="product.finPrdtCd" class="product" @click="goToDetail(product)">
       <div class="left">
         <img :src="getBankIcon(product.bankName)" class="bank-icon" />
         <div class="info">
@@ -156,10 +143,10 @@ function handlePageChange(page) {
 
 <style scoped>
 .product-list-wrapper {
-  background: white;
+  background: #ffffff;
   padding: 2rem;
-  border-radius: 1.5rem;
-  box-shadow: inset 0 0 12px #ddd;
+  border-radius: 20px;
+  box-shadow: inset 0 0 12px #3573ee;
 }
 
 .header-row {
@@ -188,6 +175,10 @@ function handlePageChange(page) {
   align-items: center;
   border-bottom: 1px solid #eee;
   padding: 1rem 0;
+}
+
+.product:hover {
+  cursor: pointer;
 }
 
 .left {

--- a/frontend/src/components/product/detail/ProductInfo.vue
+++ b/frontend/src/components/product/detail/ProductInfo.vue
@@ -53,11 +53,7 @@ const infoData = computed(() => [
       </template>
 
       <template v-else>
-        <div
-          v-for="item in infoData.slice(0, 4)"
-          :key="item.label"
-          class="info-row"
-        >
+        <div v-for="item in infoData.slice(0, 4)" :key="item.label" class="info-row">
           <div class="label">{{ item.label }}</div>
           <div class="value" v-html="item.value.replaceAll('\n', '<br />')" />
         </div>
@@ -65,9 +61,7 @@ const infoData = computed(() => [
     </div>
 
     <div class="more-btn-wrapper" v-if="!isExpanded">
-      <button class="more-btn" @click="isExpanded = true">
-        더보기 <span class="icon">⌄</span>
-      </button>
+      <button class="more-btn" @click="isExpanded = true">더보기<br></br><i class="fa-solid fa-chevron-down"></i></button>
     </div>
   </div>
 </template>
@@ -77,7 +71,7 @@ const infoData = computed(() => [
   background: white;
   border-radius: 1.5rem;
   padding: 2rem;
-  box-shadow: inset 0 0 12px #a1c4fd;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   margin-top: 1.5rem;
   font-size: 1rem;
 }
@@ -119,11 +113,16 @@ const infoData = computed(() => [
 }
 
 .more-btn {
-  border: 1px solid #ccc;
+  border: 0 solid #ccc;
   padding: 0.6rem 1.2rem;
   border-radius: 0.5rem;
   background: white;
-  cursor: pointer;
   font-weight: bold;
+}
+
+.more-btn:hover {
+  cursor: pointer;
+  transform: translateY(-2px);
+  transition: all 0.2s ease;
 }
 </style>

--- a/frontend/src/components/product/detail/ProductRate.vue
+++ b/frontend/src/components/product/detail/ProductRate.vue
@@ -31,9 +31,7 @@ const extraInfo = computed(() => {
     result.push({ label: '조건', value: props.product.spclCnd });
   }
 
-  const types = [
-    ...new Set((props.product.options || []).map((o) => o.rsrvTypeNm)),
-  ].join(', ');
+  const types = [...new Set((props.product.options || []).map((o) => o.rsrvTypeNm))].join(', ');
   if (types) {
     result.push({ label: '유형', value: types });
   }
@@ -54,17 +52,12 @@ const formattedAmount = computed(() => {
 
 // 💸 계산 로직
 const interest = computed(() => {
-  const rate =
-    selectedTab.value === 'max'
-      ? rates.value.max / 100
-      : rates.value.basic / 100;
+  const rate = selectedTab.value === 'max' ? rates.value.max / 100 : rates.value.basic / 100;
   return Math.floor(parsedAmount.value * rate);
 });
 
 const tax = computed(() => Math.floor(interest.value * taxRate));
-const afterTax = computed(
-  () => parsedAmount.value + interest.value - tax.value
-);
+const afterTax = computed(() => parsedAmount.value + interest.value - tax.value);
 
 function onInputChange(e) {
   const onlyNumbers = e.target.value.replace(/\D/g, '');
@@ -106,12 +99,7 @@ function clearInput() {
 
     <!-- 예치금액 입력 -->
     <div class="amount-input">
-      <input
-        type="text"
-        :value="formattedAmount"
-        @input="onInputChange"
-        placeholder="예치금액을 입력해주세요"
-      />
+      <input type="text" :value="formattedAmount" @input="onInputChange" placeholder="예치금액을 입력해주세요" />
       <span>원</span>
       <button class="clear-btn" @click="clearInput">×</button>
     </div>
@@ -120,16 +108,10 @@ function clearInput() {
 
     <!-- 탭 버튼 -->
     <div class="tab-buttons">
-      <button
-        :class="{ active: selectedTab === 'max' }"
-        @click="selectedTab = 'max'"
-      >
+      <button :class="{ active: selectedTab === 'max' }" @click="selectedTab = 'max'">
         최고금리 <span>{{ rates.max.toFixed(2) }}%</span>
       </button>
-      <button
-        :class="{ active: selectedTab === 'basic' }"
-        @click="selectedTab = 'basic'"
-      >
+      <button :class="{ active: selectedTab === 'basic' }" @click="selectedTab = 'basic'">
         기본금리 <span>{{ rates.basic.toFixed(2) }}%</span>
       </button>
     </div>
@@ -188,7 +170,7 @@ function clearInput() {
   background: white;
   border-radius: 1.5rem;
   padding: 2rem;
-  box-shadow: inset 0 0 12px #a1c4fd;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   margin-top: 1.5rem;
   font-size: 1rem;
 }

--- a/frontend/src/components/product/detail/ProductSummaryCard.vue
+++ b/frontend/src/components/product/detail/ProductSummaryCard.vue
@@ -11,17 +11,12 @@ const iconModules = import.meta.glob('@/assets/images/bankIcon/*.png', {
   eager: true,
   import: 'default',
 });
-const defaultIcon = new URL(
-  '@/assets/images/bankIcon/default.png',
-  import.meta.url
-).href;
+const defaultIcon = new URL('@/assets/images/bankIcon/default.png', import.meta.url).href;
 
 const getBankIcon = (bankName) => {
   const english = bankNameMap[bankName];
   if (!english) return defaultIcon;
-  const match = Object.entries(iconModules).find(([path]) =>
-    path.includes(`/${english}.png`)
-  );
+  const match = Object.entries(iconModules).find(([path]) => path.includes(`/${english}.png`));
   return match ? match[1] : defaultIcon;
 };
 
@@ -62,13 +57,9 @@ const openBankHomepage = () => {
       <span class="term">(12개월, 세전)</span>
     </div>
 
-    <button class="cta-button" @click="openBankHomepage">
-      공식 홈페이지 더 알아보기
-    </button>
+    <button class="cta-button" @click="openBankHomepage">공식 홈페이지 더 알아보기</button>
 
-    <div class="footer-note">
-      금융 상품 가입 후 ‘홈에서 자산 조회’를 클릭하여 금융 상품을 연결하세요!
-    </div>
+    <div class="footer-note">금융 상품 가입 후 ‘홈에서 자산 조회’를 클릭하여 금융 상품을 연결하세요!</div>
   </div>
 </template>
 
@@ -77,7 +68,7 @@ const openBankHomepage = () => {
   background: white;
   padding: 3rem 4rem 2rem 4rem;
   border-radius: 1.5rem;
-  box-shadow: inset 0 0 12px #3573ee;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -155,6 +146,12 @@ const openBankHomepage = () => {
   border-radius: 0.5rem;
   cursor: pointer;
   margin-top: 1rem;
+}
+
+.cta-button:active {
+  background: #ffffff;
+  color: #000000;
+  border: 1px solid #000000;
 }
 
 .footer-note {

--- a/frontend/src/components/product/detail/ProductSummaryNote.vue
+++ b/frontend/src/components/product/detail/ProductSummaryNote.vue
@@ -4,9 +4,7 @@ const props = defineProps({
 });
 
 // AI 요약이 없다면 안내 메시지로 대체
-const summaryText =
-  props.product.summary?.trim() ||
-  `이 상품에 대한 요약 정보가 존재하지 않습니다.`;
+const summaryText = props.product.summary?.trim() || `이 상품에 대한 요약 정보가 존재하지 않습니다.`;
 </script>
 
 <template>
@@ -17,10 +15,7 @@ const summaryText =
         <span class="title">상품 3줄 요약</span>
         <span>✨</span>
       </div>
-      <div class="desc">
-        해당 요약은 AI가 자동 생성한 설명입니다. 실제 상품 약관과는 다를 수
-        있습니다.
-      </div>
+      <div class="desc">해당 요약은 AI가 자동 생성한 설명입니다. 실제 상품 약관과는 다를 수 있습니다.</div>
     </div>
     <hr />
     <div class="content">
@@ -34,7 +29,7 @@ const summaryText =
   background: white;
   border-radius: 1.5rem;
   padding: 2rem;
-  box-shadow: inset 0 0 12px #a1c4fd;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   margin-top: 1.5rem;
   font-size: 1rem;
 }

--- a/frontend/src/components/product/filter/BankFilter.vue
+++ b/frontend/src/components/product/filter/BankFilter.vue
@@ -27,9 +27,7 @@ const iconModules = import.meta.glob('@/assets/images/bankIcon/*.png', {
 
 // 은행 이름(영문)을 받아 아이콘 경로를 반환
 const getBankIcon = (iconName) => {
-  const match = Object.entries(iconModules).find(([path]) =>
-    path.includes(`/${iconName}.png`)
-  );
+  const match = Object.entries(iconModules).find(([path]) => path.includes(`/${iconName}.png`));
   return match ? match[1] : '';
 };
 
@@ -92,9 +90,9 @@ function toggleBank(name) {
 }
 
 .bank-box {
-  background: white;
+  background: #ffffff;
   border: 1px solid #ddd;
-  border-radius: 1rem;
+  border-radius: 20px;
   width: 100px;
   height: 90px;
   padding: 0.5rem 0.3rem;
@@ -102,10 +100,15 @@ function toggleBank(name) {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
   box-shadow: none;
   transition: box-shadow 0.2s, border-color 0.2s;
   flex-shrink: 0;
+}
+
+.bank-box:hover {
+  cursor: pointer;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
 .bank-box img {

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -8,6 +8,7 @@ import HomeToTax from '@/components/homePage/HomeToTaxComponent.vue';
 import HomeToProduct from '@/components/homePage/HomeToProductComponent.vue';
 import HomeToGoal from '@/components/homePage/HomeToGoalComponent.vue';
 import QuizModal from '@/components/QuizModal.vue';
+import ScrollTopButton from '@/components/layouts/ScrollTopButton.vue';
 import { ref, computed } from 'vue';
 import { userAuthStore } from '@/stores/auth';
 import { useRouter } from 'vue-router';
@@ -53,13 +54,6 @@ const updateChart = () => {
   if (chartComponentRef.value && chartComponentRef.value.fetchUserAssetChart) {
     chartComponentRef.value.fetchUserAssetChart();
   }
-};
-
-const scrollToTop = () => {
-  window.scrollTo({
-    top: 0,
-    behavior: 'smooth',
-  });
 };
 </script>
 
@@ -113,11 +107,7 @@ const scrollToTop = () => {
     </div>
 
     <!-- ScrollToTop 버튼 -->
-    <div class="scroll-top-btn" @click="scrollToTop">
-      <div class="scroll-top-icon">
-        <i class="fa-solid fa-chevron-up" style="color: #3573ee"></i>
-      </div>
-    </div>
+    <ScrollTopButton />
 
     <!-- 퀴즈 모달 -->
     <QuizModal :show="showQuizModal" @close="closeQuizModal" />
@@ -141,7 +131,7 @@ const scrollToTop = () => {
   /* max-width: none; 최대 너비 제한 해제 */
   margin: 0 auto; /* 중앙 정렬 */
   margin-top: 15px;
-  padding: 30px 70px;
+  padding: 30px 12px;
   display: flex;
   flex-direction: column;
   gap: 30px;
@@ -153,7 +143,7 @@ const scrollToTop = () => {
 /* ===== 1. 자산 현황 + 차트 영역 ===== */
 .asset-section {
   display: flex;
-  gap: 0px; /* 자산 컴포넌트와 차트 컴포넌트 사이 간격 */
+  gap: 32px; /* 자산 컴포넌트와 차트 컴포넌트 사이 간격 */
   width: 100%;
   /* height: 630px; */
   max-width: none; /* 최대 너비 제한 해제 */
@@ -166,7 +156,7 @@ const scrollToTop = () => {
   align-items: center;
   justify-content: center;
   min-height: 200px;
-  padding: 20px;
+  padding: 20px 0 20px 20px;
 }
 
 .chart-component {
@@ -175,13 +165,13 @@ const scrollToTop = () => {
   align-items: center;
   justify-content: center;
   min-height: 200px;
-  padding: 20px;
+  padding: 20px 20px 20px 0;
 }
 
 /* ===== 2. 광고 + 퀴즈/공지사항 영역 ===== */
 .middle-section {
   display: flex;
-  gap: 20px;
+  gap: 32px;
   min-height: 250px;
   width: 100%;
   padding-right: 20px;
@@ -304,47 +294,12 @@ const scrollToTop = () => {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
-/* ===== ScrollToTop 버튼 ===== */
-.scroll-top-btn {
-  cursor: pointer;
-  position: fixed;
-  bottom: 30px;
-  right: 30px;
-  width: 56px;
-  height: 56px;
-  background-color: #ffffff;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: bold;
-  color: #374151;
-  border: 2px solid #e5e7eb;
-  z-index: 1000;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  transition: all 0.3s ease;
-}
-
-.scroll-top-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
-}
-
-.scroll-top-icon {
-  font-size: 20px;
-  transition: transform 0.3s ease;
-}
-
-.scroll-top-btn:hover .scroll-top-icon {
-  transform: translateY(-2px);
-}
-
 /* ===== 태블릿 반응형 (1024px 이하) ===== */
 @media (max-width: 1024px) {
   .main-content {
     max-width: none;
     margin-top: 0px;
-    padding: 25px 0px; /* 좌우 패딩 없음 */
+    padding: 25px 12px; /* 좌우 패딩 없음 */
     gap: 25px;
   }
 
@@ -356,9 +311,12 @@ const scrollToTop = () => {
     max-width: 100%;
   }
 
-  .asset-section,
+  .asset-section {
+    gap: 16px;
+  }
+
   .middle-section {
-    gap: 15px;
+    gap: 16px;
   }
 
   /* 자산 섹션이 없을 때 여백 조정 */
@@ -374,13 +332,6 @@ const scrollToTop = () => {
     height: 250px;
   }
 
-  .scroll-top-btn {
-    width: 52px;
-    height: 52px;
-    bottom: 25px;
-    right: 25px;
-  }
-
   .ad-component {
     border-radius: 0 20px 20px 0; /* border-radius 유지 */
     /* 1024px 이하에서는 main-content의 좌우 패딩이 0이므로 음수 마진 필요 없음 */
@@ -393,23 +344,24 @@ const scrollToTop = () => {
 @media (max-width: 768px) {
   .main-content {
     margin: 15px 0px 0px 0px;
-    padding: 10px 0px; /* 좌우 패딩 없음 */
+    padding: 10px 12px; /* 좌우 패딩 없음 */
     gap: 15px;
   }
 
   /* 자산 + 차트 세로 배치 */
   .asset-section {
     flex-direction: column;
-    gap: 0px;
+    gap: 20px;
   }
 
   .asset-info-component {
     min-width: 160px;
-    padding-bottom: 0px;
+    padding: 20px 20px 0 20px;
   }
 
   .chart-component {
     min-height: 160px;
+    padding: 0 20px 20px 20px;
   }
 
   /* 광고 + 퀴즈/공지 세로 배치 */
@@ -469,94 +421,6 @@ const scrollToTop = () => {
     height: 220px;
     font-size: 12px;
     border-radius: 12px;
-  }
-
-  /* 스크롤 버튼 */
-  .scroll-top-btn {
-    width: 48px;
-    height: 48px;
-    bottom: 20px;
-    right: 20px;
-  }
-
-  .scroll-top-icon {
-    font-size: 18px;
-  }
-}
-
-/* ===== 작은 모바일 반응형 (480px 이하) ===== */
-@media (max-width: 480px) {
-  .main-content {
-    margin-top: 0px;
-    gap: 15px;
-  }
-
-  .asset-info-component,
-  .chart-component {
-    min-height: 140px;
-  }
-
-  .chart-component {
-    font-size: 14px;
-  }
-
-  /* 자산 섹션이 없을 때 여백 조정 */
-  .middle-section.no-asset-section {
-    margin-top: 10px;
-  }
-
-  .ad-component {
-    height: 150px;
-    font-size: 14px;
-    border-radius: 0 20px 20px 0; /* border-radius 유지 */
-    margin-left: 0; /* 좌우 패딩이 0이므로 음수 마진 필요 없음 */
-    width: 100%; /* 부모 너비에 꽉 채움 */
-  }
-
-  .right-section {
-    flex-direction: column;
-    gap: 10px;
-  }
-
-  .quiz-component,
-  .notice-component {
-    min-height: 100px;
-    font-size: 12px;
-  }
-
-  .service-title-section {
-    height: 60px;
-    font-size: 14px;
-  }
-
-  .service-title {
-    font-size: 20px;
-  }
-
-  .service-content {
-    font-size: 12px;
-    margin-top: 5px;
-  }
-
-  .nav-card {
-    height: 160px;
-    font-size: 11px;
-    border-radius: 10px;
-  }
-
-  .bottom-navigation-section {
-    gap: 8px;
-  }
-
-  .scroll-top-btn {
-    width: 44px;
-    height: 44px;
-    bottom: 15px;
-    right: 15px;
-  }
-
-  .scroll-top-icon {
-    font-size: 16px;
   }
 }
 </style>

--- a/frontend/src/pages/product/ProductDetailPage.vue
+++ b/frontend/src/pages/product/ProductDetailPage.vue
@@ -5,6 +5,7 @@ import ProductSummaryCard from '@/components/product/detail/ProductSummaryCard.v
 import ProductSummaryNote from '@/components/product/detail/ProductSummaryNote.vue';
 import ProductInfoBox from '@/components/product/detail/ProductInfo.vue';
 import ProductRateBox from '@/components/product/detail/ProductRate.vue';
+import ScrollTopButton from '@/components/layouts/ScrollTopButton.vue';
 import { fetchProductDetail } from '@/api/productApi';
 
 const props = defineProps({
@@ -38,30 +39,40 @@ function goBackToList() {
 
 <template>
   <div class="product-detail-page">
-    <!-- 🔙 목록으로 돌아가기 -->
-    <div class="back-button" @click="goBackToList">← 목록으로 돌아가기</div>
+    <div class="product-detail-wrapper">
+      <!-- 🔙 목록으로 돌아가기 -->
+      <div class="back-button" @click="goBackToList"><i class="fa-solid fa-arrow-left"></i> 목록으로 돌아가기</div>
 
-    <template v-if="isLoading">
-      <p>로딩 중...</p>
-    </template>
+      <template v-if="isLoading">
+        <p>로딩 중...</p>
+      </template>
 
-    <template v-else-if="product">
-      <ProductSummaryCard :product="product" />
-      <ProductSummaryNote :product="product" />
-      <ProductInfoBox :product="product" />
-      <ProductRateBox :product="product" />
-    </template>
+      <template v-else-if="product">
+        <ProductSummaryCard :product="product" />
+        <ProductSummaryNote :product="product" />
+        <ProductInfoBox :product="product" />
+        <ProductRateBox :product="product" />
+      </template>
 
-    <div v-else class="not-found">해당 상품을 찾을 수 없습니다.</div>
+      <div v-else class="not-found">해당 상품을 찾을 수 없습니다.</div>
+    </div>
+    <ScrollTopButton />
   </div>
 </template>
 
 <style scoped>
 .product-detail-page {
-  max-width: 1024px;
   margin: 0 auto;
-  padding: 2rem 1rem 3rem;
+  padding: 60px 100px 40px;
   box-sizing: border-box;
+  width: 100%;
+  background-color: #fbfbfb;
+}
+
+.product-detail-wrapper {
+  padding: 0 12px;
+  max-width: 1280px;
+  margin: 0 auto;
 }
 
 .back-button {
@@ -70,5 +81,17 @@ function goBackToList() {
   margin: 1rem;
   display: inline-block;
   cursor: pointer;
+}
+
+@media (max-width: 1024px) {
+  .product-detail-page {
+    padding: 60px 70px 40px;
+  }
+}
+
+@media (max-width: 768px) {
+  .product-detail-page {
+    padding: 60px 30px 40px;
+  }
 }
 </style>

--- a/frontend/src/pages/product/ProductRecommendPage.vue
+++ b/frontend/src/pages/product/ProductRecommendPage.vue
@@ -3,39 +3,62 @@ import { ref } from 'vue';
 import ProductCarousel from '@/components/product/ProductCarousel.vue';
 import ProductFilterBar from '@/components/product/ProductFilterBar.vue';
 import ProductList from '@/components/product/ProductList.vue';
+import ScrollTopButton from '@/components/layouts/ScrollTopButton.vue';
 
 // 상위에서 필터 상태 관리
 const filters = ref({
-    bankNames: [],
-    joinMembers: [],
-    productType: null,
-    minSaveTrm: null,
-    maxSaveTrm: null,
-    minAmount: null,
-    maxAmount: null,
-    hasSpclCnd: false,
-    __active: null,
+  bankNames: [],
+  joinMembers: [],
+  productType: null,
+  minSaveTrm: null,
+  maxSaveTrm: null,
+  minAmount: null,
+  maxAmount: null,
+  hasSpclCnd: false,
+  __active: null,
 });
 </script>
 
 <template>
-    <div class="product-recommendation-page">
-        <!-- 추천 캐러셀 -->
-        <ProductCarousel />
+  <div class="product-recommendation-page">
+    <div class="product-wrapper">
+      <!-- 추천 캐러셀 -->
+      <ProductCarousel />
 
-        <!-- 필터 영역 (v-model로 상태 공유) -->
-        <ProductFilterBar v-model:filters="filters" />
+      <!-- 필터 영역 (v-model로 상태 공유) -->
+      <ProductFilterBar v-model:filters="filters" />
 
-        <!-- 필터된 리스트 출력 -->
-        <ProductList :filters="filters" />
+      <!-- 필터된 리스트 출력 -->
+      <ProductList :filters="filters" />
     </div>
+    <ScrollTopButton />
+  </div>
 </template>
 
 <style scoped>
 .product-recommendation-page {
-    max-width: 1024px;
-    margin: 0 auto;
-    padding: 2rem 1rem 3rem;
-    box-sizing: border-box;
+  width: 100%;
+  padding: 60px 90px 40px;
+  box-sizing: border-box;
+  background-color: #fbfbfb;
+}
+
+.product-wrapper {
+  background-color: transparent;
+  margin: 0 auto;
+  padding: 0 12px;
+  max-width: none;
+}
+
+@media (max-width: 1024px) {
+  .product-recommendation-page {
+    padding: 60px 70px;
+  }
+}
+
+@media (max-width: 768px) {
+  .product-recommendation-page {
+    padding: 60px 30px;
+  }
 }
 </style>

--- a/frontend/src/pages/tax/TaxPage.vue
+++ b/frontend/src/pages/tax/TaxPage.vue
@@ -131,17 +131,17 @@ export default {
 <style scoped>
 /* 기존 스타일 유지 */
 .tax-page {
-  background-color: #ffffff;
-  padding: 40px;
+  background-color: #fbfbfb;
+  padding: 60px 32px 40px;
   min-height: 100vh;
   box-sizing: border-box;
 }
 .tax-wrapper {
-  background-color: #ffffff;
+  background-color: transparent;
   border-radius: 16px;
   padding: 32px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  max-width: 1280px;
+  max-width: none;
   margin: 0 auto;
 }
 .tax-content {
@@ -150,7 +150,7 @@ export default {
   align-items: flex-start;
 }
 .tax-grid {
-  background-color: #ffffff;
+  background-color: transparent;
   flex: 1.618;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -159,7 +159,7 @@ export default {
 .tax-card {
   background-color: #ffffff;
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   padding: 16px;
   text-align: center;
   transition: all 0.2s ease;
@@ -181,7 +181,7 @@ export default {
   min-width: 280px;
   background-color: #ffffff;
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   padding: 20px;
   box-sizing: border-box;
 }
@@ -248,7 +248,7 @@ export default {
 
 @media (max-width: 1024px) {
   .tax-wrapper {
-    padding: 16px; /* 패딩 약간 줄임 */
+    padding: 24px; /* 패딩 약간 줄임 */
   }
   .tax-grid {
     flex: 1.2;
@@ -293,10 +293,15 @@ export default {
 
     /* 레이아웃 속성 */
     gap: 16px;
-    padding: 8px 0 16px 0;
+    padding: 16px 16px; /* 위아래 16px, 좌우 16px */
+    border-radius: 12px;
+    /* box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1); */
 
-    /* 너비 설정 - 부모 컨테이너보다 넓게 */
-    width: 100%;
+    /* 스크롤 안쪽에서 양옆 여백 */
+    scroll-padding: 0 16px; /* 스크롤 시 양쪽에 16px 여백 */
+
+    /* 너비 설정 */
+    width: 100%; /* 부모 너비에 맞춤 */
 
     /* 스크롤 동작 강제 */
     scroll-behavior: smooth;

--- a/frontend/src/pages/tax/details/DefaultInfo.vue
+++ b/frontend/src/pages/tax/details/DefaultInfo.vue
@@ -1,64 +1,60 @@
 <template>
-  <div class="tax-info">
-    <h2 class="section-title">🐘 세금 정보 서비스</h2>
-    <p class="section-desc">
-      2024년 귀속 연말정산 PDF 자료를 기반으로, 항목별 작년 금액과 세금 관련 안내를 제공합니다.
-    </p>
+  <h2 class="section-title">🐘 세금 정보 서비스</h2>
+  <p class="section-desc">2024년 귀속 연말정산 PDF 자료를 기반으로, 항목별 작년 금액과 세금 관련 안내를 제공합니다.</p>
 
-    <ul class="info-list">
-      <li>정보는 사용자가 홈택스 등에 제출한 자료를 바탕으로 하며, 실제와 다를 수 있습니다.</li>
-      <li>금액·항목이 사실과 다를 경우 원천 기관(카드사·의료기관 등)에 확인하세요.</li>
-      <li>절세 방안은 일반적인 안내이며, 개인 상황에 따라 적용 여부가 다를 수 있습니다.</li>
-      <li>최종 정산 결과는 반드시 사용자가 직접 확인해야 합니다.</li>
-    </ul>
+  <ul class="info-list">
+    <li>정보는 사용자가 홈택스 등에 제출한 자료를 바탕으로 하며, 실제와 다를 수 있습니다.</li>
+    <li>금액·항목이 사실과 다를 경우 원천 기관(카드사·의료기관 등)에 확인하세요.</li>
+    <li>절세 방안은 일반적인 안내이며, 개인 상황에 따라 적용 여부가 다를 수 있습니다.</li>
+    <li>최종 정산 결과는 반드시 사용자가 직접 확인해야 합니다.</li>
+  </ul>
 
-    <button class="info-button" @click="showModal = true">작년 연말정산 조회하기</button>
+  <button class="info-button" @click="showModal = true">작년 연말정산 조회하기</button>
 
-    <div v-if="showModal" class="popup-overlay">
-      <div class="popup-content agreement-popup">
-        <button class="popup-close" @click="closePopup">✕</button>
+  <div v-if="showModal" class="popup-overlay">
+    <div class="popup-content agreement-popup">
+      <button class="popup-close" @click="closePopup">✕</button>
 
-        <div v-if="step === 'agreement'">
-          <h2 class="popup-title">개인(신용)정보 수집·이용 동의</h2>
-          <p class="popup-desc">
-            [필수] 전자금융거래 정보처리 동의<br />
-            전자금융거래 서비스 제공·관리·개선 등을 목적으로 합니다.
-          </p>
+      <div v-if="step === 'agreement'">
+        <h2 class="popup-title">개인(신용)정보 수집·이용 동의</h2>
+        <p class="popup-desc">
+          [필수] 전자금융거래 정보처리 동의<br />
+          전자금융거래 서비스 제공·관리·개선 등을 목적으로 합니다.
+        </p>
 
-          <section class="popup-section year-section">
-            <label class="popup-label">연도 :</label>
-            <select v-model="selectedYear" class="popup-select">
-              <option disabled value="">연도를 선택하세요</option>
-              <option v-for="year in yearOptions" :key="year" :value="year">{{ year }}</option>
-            </select>
-          </section>
+        <section class="popup-section year-section">
+          <label class="popup-label">연도 :</label>
+          <select v-model="selectedYear" class="popup-select">
+            <option disabled value="">연도를 선택하세요</option>
+            <option v-for="year in yearOptions" :key="year" :value="year">{{ year }}</option>
+          </select>
+        </section>
 
-          <section class="popup-section agree-section">
-            <p>위 개인정보 수집·이용에 동의하십니까?</p>
-            <div class="radio-group">
-              <label><input type="radio" value="Y" v-model="agree" /> 동의함</label>
-              <label><input type="radio" value="N" v-model="agree" /> 동의안함</label>
-            </div>
-          </section>
-
-          <div class="popup-actions">
-            <button class="agree-btn" @click="startVerification">동의</button>
+        <section class="popup-section agree-section">
+          <p>위 개인정보 수집·이용에 동의하십니까?</p>
+          <div class="radio-group">
+            <label><input type="radio" value="Y" v-model="agree" /> 동의함</label>
+            <label><input type="radio" value="N" v-model="agree" /> 동의안함</label>
           </div>
+        </section>
+
+        <div class="popup-actions">
+          <button class="agree-btn" @click="startVerification">동의</button>
         </div>
+      </div>
 
-        <div v-else-if="step === 'verifying'" class="center-content">
-          <p class="verify-text">🔐 인증중입니다...<br />인증이 완료되면 "인증완료" 버튼을 눌러주세요.</p>
-          <div class="popup-actions">
-            <button class="close-btn" @click="closePopup">닫기</button>
-            <button class="confirm-btn" @click="goToCompleted">인증완료</button>
-          </div>
+      <div v-else-if="step === 'verifying'" class="center-content">
+        <p class="verify-text">🔐 인증중입니다...<br />인증이 완료되면 "인증완료" 버튼을 눌러주세요.</p>
+        <div class="popup-actions">
+          <button class="close-btn" @click="closePopup">닫기</button>
+          <button class="confirm-btn" @click="goToCompleted">인증완료</button>
         </div>
+      </div>
 
-        <div v-else-if="step === 'completed'" class="center-content">
-          <p class="verify-complete">✅ 인증이 완료되었습니다.</p>
-          <div class="popup-actions">
-            <button class="close-btn" @click="closePopup">닫기</button>
-          </div>
+      <div v-else-if="step === 'completed'" class="center-content">
+        <p class="verify-complete">✅ 인증이 완료되었습니다.</p>
+        <div class="popup-actions">
+          <button class="close-btn" @click="closePopup">닫기</button>
         </div>
       </div>
     </div>
@@ -106,13 +102,6 @@ export default {
 </script>
 
 <style scoped>
-.tax-info {
-  font-family: 'Noto Sans KR', sans-serif;
-  padding: 24px;
-  background-color: #ffffff;
-  color: #1f2937;
-}
-
 .section-title {
   font-size: 20px;
   font-weight: bold;

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -41,7 +41,7 @@ export const userAuthStore = defineStore('auth', () => {
     } catch (error) {
       console.error('localStorage 파싱 오류:', error);
     }
-    
+
     const name = state.value.user.userName;
     return name || '';
   });
@@ -98,9 +98,9 @@ export const userAuthStore = defineStore('auth', () => {
   const getToken = () => state.value.token;
 
   const setToken = (token) => {
-    state.value.token = token
-    localStorage.setItem('auth', JSON.stringify(state.value))
-  }
+    state.value.token = token;
+    localStorage.setItem('auth', JSON.stringify(state.value));
+  };
 
   const load = () => {
     const auth = localStorage.getItem('auth');


### PR DESCRIPTION
## 📌 Issues
- closed #79

## 🏁 Work Description
- 어떤 작업을 했는지
- 금융상품추천페이지 반응형 구현(1024px, 768px)
- font Awesome 아이콘으로 변경
- ScrollTopButton 페이지에 추가
- 세금관리 페이지 스타일 수정
- 홈페이지 하단의 각 서비스로 이동하는 3개의 컴포넌트의 이미지 크기 버그 수정

## 💬 PR Points
- 어떤 부분을 리뷰어가 중점적으로 보아야 하는지
- 우려사항 등

## 📷 Screenshot
금융상품추천 1024px
<img width="801" height="656" alt="image" src="https://github.com/user-attachments/assets/c44c5d0b-15ff-40f4-a94f-a2f8dbf01770" />
<br/>
768px
<img width="578" height="771" alt="image" src="https://github.com/user-attachments/assets/ebfbe43b-c26a-4d48-8f9c-6abb034163ae" /><br/>
금융상품추천 상세 페이지 1024px
<img width="774" height="583" alt="image" src="https://github.com/user-attachments/assets/3974c300-634b-4c9c-802a-9886d4122b84" /><br/>
768px
<img width="590" height="776" alt="image" src="https://github.com/user-attachments/assets/ac3f9248-4409-401a-be3c-00c5a5403922" />


