### PR TITLE
Feature: 금융상품추천 스타일 수정

### DIFF
--- a/frontend/src/components/homePage/ADComponent.vue
+++ b/frontend/src/components/homePage/ADComponent.vue
@@ -38,7 +38,7 @@
 </template>
 <script setup>
 const goToDetail = () => {
-  // 자세히 알아보기 클릭 처리
+    window.open('https://ylaccount.kinfa.or.kr/main', '_blank');
 };
 </script>
 <style scoped>
@@ -46,10 +46,9 @@ const goToDetail = () => {
   background: #ffffff;
   border-radius: 20px;
   padding: 48px 48px 0px 48px;
-  width: 100%; /* 부모의 너비를 꽉 채우도록 설정 */
-  /* max-width는 제거하거나, 특정 최대 너비가 필요하다면 설정 */
-  min-height: 400px; /* 적절한 최소 높이 설정 */
-  margin: 0 auto; /* 중앙 정렬 유지 */
+  width: 100%; 
+  min-height: 400px; 
+  margin: 0 auto; 
   position: relative;
   overflow: hidden;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
@@ -58,7 +57,6 @@ const goToDetail = () => {
   justify-content: space-between;
   align-items: flex-start;
 }
-/* 상단 텍스트 콘텐츠 */
 .text-content-top {
   width: 100%;
   margin-bottom: 32px;
@@ -99,7 +97,6 @@ const goToDetail = () => {
   color: #64748b;
   line-height: 1.5;
 }
-/* 하단 섹션 래퍼: 사진과 버튼이 좌우로 나뉨 */
 .bottom-section-wrapper {
   display: flex;
   flex-direction: row;
@@ -107,29 +104,22 @@ const goToDetail = () => {
   justify-content: space-between;
   align-items: flex-end;
 }
-/* 이미지 컨테이너 스타일 */
 .image-container {
-  flex: 1; /* 남은 공간을 차지하도록 설정 */
+  flex: 1; 
   display: flex;
   justify-content: flex-start;
   background-color: transparent;
   align-items: flex-end;
   padding-right: 20px;
-  /* 이미지의 고정 너비 230px를 제거하거나 max-width와 함께 사용 */
-  /* 필요하다면 flex-basis로 최소 너비 지정 가능 */
 }
-/* 이미지 자체의 스타일 */
 .ad-image {
-  /* 이미지 컨테이너의 크기에 맞춰 유연하게 조절되도록 합니다. */
-  /* 고정 width: 230px; 를 삭제하고 max-width: 100%만 남겨둡니다. */
-  width: 250px; /* 이미지 크기 조정 */
+  width: 250px; 
   max-width: 100%;
   height: auto;
   display: block;
-  background-color: transparent; /* 배경색 제거 */
+  background-color: transparent; 
   transform: translateY(20px);
 }
-/* 자세히 알아보기 버튼 스타일 */
 .learn-more-button {
   background: #d8eaff;
   color: rgb(0, 0, 0);
@@ -145,7 +135,7 @@ const goToDetail = () => {
   cursor: pointer;
   transition: all 0.3s ease;
   box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
-  position: static; /* Flexbox 내에서 배치 */
+  position: static; 
 }
 .learn-more-button:hover {
   background: #2563eb;
@@ -157,13 +147,12 @@ const goToDetail = () => {
   width: 20px;
   height: 20px;
 }
-/* 반응형 디자인 */
 @media (max-width: 1024px) {
   .ad-card {
     padding: 32px 24px;
     min-height: auto;
-    border-radius: 0 20px 20px 0; /* 반응형에서도 오른쪽만 둥근 모서리 유지 */
-    width: 100%; /* 반응형에서도 부모 너비 채우도록 */
+    border-radius: 0 20px 20px 0; 
+    width: 100%; 
   }
   .text-content-top {
     margin-bottom: 24px;

--- a/frontend/src/components/product/ProductCarousel.vue
+++ b/frontend/src/components/product/ProductCarousel.vue
@@ -1,100 +1,81 @@
 <script setup>
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { bankNameMap } from '@/utils/bankMap';
-import { fetchRecommendedProducts } from '@/api/productApi';
-import { userAuthStore } from '@/stores/auth';
-import { useRouter } from 'vue-router';
-const router = useRouter();
+import { fetchRecommendedProducts } from '@/api/productApi'
+import { userAuthStore } from '@/stores/auth'
+import { useRouter } from 'vue-router'
+const router = useRouter()
 function goToDetail(finPrdtCd) {
-  router.push(`/product/${finPrdtCd}`);
+  router.push(`/product/${finPrdtCd}`)
 }
-const currentPage = ref(0);
-const itemsPerPage = 2;
-const products = ref([]);
-const windowWidth = ref(window.innerWidth); // 반응형을 위한 상태
+const currentPage = ref(0)
+const itemsPerPage = 2
+const products = ref([])
+const windowWidth = ref(window.innerWidth)
 
-const auth = userAuthStore();
-const userId = auth.state.user.userId;
-const userName = auth.state.user.userName || '김콕재';
+const auth = userAuthStore()
+const userId = auth.state.user.userId
+const userName = auth.state.user.userName || '김콕재'
 const iconModules = import.meta.glob('@/assets/images/bankIcon/*.png', {
   eager: true,
   import: 'default',
-});
-const defaultIcon = new URL('@/assets/images/bankIcon/default.png', import.meta.url).href;
+})
+const defaultIcon = new URL('@/assets/images/bankIcon/default.png', import.meta.url).href
 const getBankIcon = (bankName) => {
-  const english = bankNameMap[bankName];
-  if (!english) return defaultIcon;
-  const match = Object.entries(iconModules).find(([path]) => path.includes(`/${english}.png`));
-  return match ? match[1] : defaultIcon;
-};
-
-// 화면 크기 변경 감지
+  const english = bankNameMap[bankName]
+  if (!english) return defaultIcon
+  const match = Object.entries(iconModules).find(([path]) => path.includes(`/${english}.png`))
+  return match ? match[1] : defaultIcon
+}
 const handleResize = () => {
-  windowWidth.value = window.innerWidth;
-  // 화면 크기가 변경되면 현재 페이지 초기화
-  currentPage.value = 0;
-};
-
+  windowWidth.value = window.innerWidth
+  currentPage.value = 0
+}
 onMounted(async () => {
   try {
-    const result = await fetchRecommendedProducts(userId);
-    // 최대 4개 표시
-    products.value = result.slice(0, 4);
+    const result = await fetchRecommendedProducts(userId)
+    products.value = result;
   } catch (error) {
-    console.error('추천 상품 불러오기 실패:', error);
+    console.error('추천 상품 불러오기 실패:', error)
   }
-  // 리사이즈 이벤트 리스너 추가
-  window.addEventListener('resize', handleResize);
-});
-
+  window.addEventListener('resize', handleResize)
+})
 onUnmounted(() => {
-  // 리사이즈 이벤트 리스너 제거
-  window.removeEventListener('resize', handleResize);
-});
-
-// 데스크탑에서는 모든 카드 표시, 모바일에서는 페이징
+  window.removeEventListener('resize', handleResize)
+})
 const visibleProducts = computed(() => {
-  // 데스크탑 (1025px 이상)에서는 모든 상품 표시
+  
   if (windowWidth.value > 1024) {
-    return products.value;
+    const itemsPerPageDesktop = 3
+    const start = currentPage.value * itemsPerPageDesktop
+    const end = start + itemsPerPageDesktop
+    return products.value.slice(start, end)
   }
-
-  // 모바일에서는 페이징
-  const start = currentPage.value * itemsPerPage;
-  const end = start + itemsPerPage;
-  return products.value.slice(start, end);
-});
-
-// 네비게이션 버튼 표시 여부
-const showNavButtons = computed(() => {
-  return windowWidth.value <= 1024 && products.value.length > itemsPerPage;
-});
+  const start = currentPage.value * itemsPerPage
+  const end = start + itemsPerPage
+  return products.value.slice(start, end)
+})
 
 const endOfSlide = computed(() => {
-  return (currentPage.value + 1) * itemsPerPage >= products.value.length;
-});
+  const currentItemsPerPage = windowWidth.value > 1024 ? 3 : itemsPerPage;
+  return (currentPage.value + 1) * currentItemsPerPage >= products.value.length;
+})
 function prevSlide() {
-  if (currentPage.value > 0) currentPage.value--;
+  if (currentPage.value > 0) currentPage.value--
 }
 function nextSlide() {
-  if (!endOfSlide.value) currentPage.value++;
+  if (!endOfSlide.value) currentPage.value++
 }
 </script>
 <template>
   <div class="carousel-wrapper">
     <div class="title">✨ {{ userName }}님의 맞춤 추천 상품 ✨</div>
     <div class="carousel-container">
-      <!-- 태블릿에서만 네비게이션 버튼 표시 -->
-      <button v-if="showNavButtons" class="nav-button" @click="prevSlide" :disabled="currentPage === 0">
+      <button class="nav-button" @click="prevSlide" :disabled="currentPage === 0">
         <i class="fa-solid fa-angle-left"></i>
       </button>
       <div class="carousel-cards">
-        <div
-          class="card"
-          v-for="product in visibleProducts"
-          :key="product.finPrdtCd"
-          @click="goToDetail(product.finPrdtCd)"
-        >
+        <div class="card" v-for="product in visibleProducts" :key="product.finPrdtCd" @click="goToDetail(product.finPrdtCd)">
           <div class="card-header">
             <img :src="getBankIcon(product.bankName)" alt="은행 로고" class="bank-icon" />
             <div>
@@ -108,9 +89,7 @@ function nextSlide() {
           <div class="highlight">✨ {{ product.reason }} ✨</div>
         </div>
       </div>
-
-      <!-- 태블릿에서만 네비게이션 버튼 표시 -->
-      <button v-if="showNavButtons" class="nav-button" @click="nextSlide" :disabled="endOfSlide">
+      <button class="nav-button" @click="nextSlide" :disabled="endOfSlide">
         <i class="fa-solid fa-angle-right"></i>
       </button>
     </div>
@@ -135,9 +114,8 @@ function nextSlide() {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
+  gap: 32px;
 }
-/* 좌우버튼 */
 .nav-button {
   background: white;
   border: 1px solid #ccc;
@@ -161,7 +139,6 @@ function nextSlide() {
   transform: translateY(-2px);
   transition: all 0.2s ease;
 }
-/* 금융 상품 */
 .carousel-cards {
   display: flex;
   gap: 8px;
@@ -246,5 +223,8 @@ function nextSlide() {
     height: 30px;
     font-size: 16px;
   }
+}
+@media (max-width: 768px) {
+
 }
 </style>


### PR DESCRIPTION
## 📌 Issues
- closed #94

## 🏁 Work Description
- 데스크탑에서 금융상품추천 카드 수 3개로 수정
- 홈페이지 광고컴포넌트에서 사이트 이동 구현

## 💬 PR Points
- 어떤 부분을 리뷰어가 중점적으로 보아야 하는지
- 우려사항 등

## 📷 Screenshot
데스크탑
<img width="1680" height="850" alt="image" src="https://github.com/user-attachments/assets/519fe8bc-ac99-4bf7-ab94-2034c506ba9c" /><br/>
태블릿(가로)
<img width="772" height="577" alt="image" src="https://github.com/user-attachments/assets/00971c07-2184-417c-bef4-d34550a11c59" /><br/>

태블릿(세로)
<img width="577" height="775" alt="image" src="https://github.com/user-attachments/assets/65e462ba-148e-42e9-9f20-8cb8c781d109" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product carousel now displays all recommended products with paginated navigation on both desktop and mobile. Desktop shows 3 items per page, mobile shows 2, and navigation buttons are always visible.

* **Refactor**
  * Improved the logic and layout of the product carousel for a more consistent user experience across devices.

* **Style**
  * Cleaned up comments and formatting in component styles without altering the visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->