### PR TITLE
Fix: 자산 불러오기 수정

### DIFF
--- a/frontend/src/api/assetApi.js
+++ b/frontend/src/api/assetApi.js
@@ -17,12 +17,20 @@ export default {
       throw error
     }
   },
-  async getYeomsky95Assets() {
-    try {
-      const { data } = await api.get('AllAccount/yeomsky95/assets')
-      return data
+  async updateBankAccount(userId) {
+     try {
+      // 백엔드에서 CODEF 처리 후 성공 여부만 반환
+      const { data } = await api.get(`api/allaccount?userId=${userId}`)
+    
+      // 성공 응답 확인
+      if (data.success) {
+        console.log('CODEF 데이터 처리 완료')
+        return data
+      } else {
+        throw new Error(data.message || '처리 실패')
+      }
     } catch (error) {
-      throw error
-    }
+    throw error
+  }
   },
 }

--- a/frontend/src/components/homePage/UserAssetComponent.vue
+++ b/frontend/src/components/homePage/UserAssetComponent.vue
@@ -117,31 +117,25 @@ const formatCurrency = amount => {
       .replace('₩', '') + ' 원'
   )
 }
-const handleAssetLookup = () => {
+const handleAssetLookup = async () => {
   if (isUpdating.value) return
-  emit('asset-lookup')
-  fetchUserAssetData()
-}
-// yeomsky95 자산 연동 메서드
-const handleYeomsky95Sync = async () => {
-  syncing.value = true
-  syncMessage.value = ''
-  syncData.value = null
+  
+  isUpdating.value = true
+  
   try {
-    const result = await assetApi.getYeomsky95Assets()
-    syncData.value = result
-    syncMessage.value =
-      'yeomsky95 사용자의 자산 정보가 성공적으로 연동되었습니다.'
-    showSyncModal.value = true
-  } catch (err) {
-    console.error('Failed to sync yeomsky95 assets:', err)
-    syncMessage.value =
-      '자산 연동에 실패했습니다: ' + (err.message || '알 수 없는 오류')
-    showSyncModal.value = true
+    // 1. 첫 번째 API 호출: CODEF 계좌 정보 업데이트
+    await assetApi.updateBankAccount(props.userId)
+    emit('asset-lookup')
+    await fetchUserAssetData()
+  } catch (error) {
+    // 첫 번째 통신 실패 시에도 기존 데이터는 조회
+    emit('asset-lookup')
+    await fetchUserAssetData()
   } finally {
-    syncing.value = false
+    isUpdating.value = false
   }
 }
+
 const closeSyncModal = () => {
   showSyncModal.value = false
   syncMessage.value = ''


### PR DESCRIPTION
## 📌 Issues
- closed #118

## 🏁 Work Description
- CODEF API를 연동하여 실시간으로 계좌 정보를 불러오도록 수정
- 계좌 정보가 자동으로 갱신되도록 로직을 추가

## 💬 PR Points
- 어떤 부분을 리뷰어가 중점적으로 보아야 하는지
- 우려사항 등

## 📷 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Asset lookup now performs a one-click bank account update before refreshing data, ensuring the latest balances are shown.
- Refactor
  - Streamlined the asset sync flow by removing the separate sync modal; updates now run inline during asset lookup.
- UX
  - During updates, the button is disabled and shows “업데이트 중...”, providing clear progress feedback.
  - On update failure, existing asset data remains visible while the app still refreshes displayed information afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->